### PR TITLE
max_new_tokens as a parameter to answer_question() and default=256 instead of 512

### DIFF
--- a/moondream/moondream.py
+++ b/moondream/moondream.py
@@ -97,7 +97,7 @@ class Moondream(PreTrainedModel):
             image_embeds,
             prompt,
             tokenizer=tokenizer,
-            max_new_tokens=max_new_tokens=,
+            max_new_tokens=max_new_tokens,
             **kwargs,
         )[0]
         cleaned_answer = answer.strip()

--- a/moondream/moondream.py
+++ b/moondream/moondream.py
@@ -87,8 +87,9 @@ class Moondream(PreTrainedModel):
         image_embeds,
         question,
         tokenizer,
-        chat_history="",
-        result_queue=None,
+        chat_history="",        
+        result_queue=None,        
+        max_new_tokens=256
         **kwargs,
     ):
         prompt = f"<image>\n\n{chat_history}Question: {question}\n\nAnswer:"
@@ -96,7 +97,7 @@ class Moondream(PreTrainedModel):
             image_embeds,
             prompt,
             tokenizer=tokenizer,
-            max_new_tokens=512,
+            max_new_tokens=max_new_tokens=,
             **kwargs,
         )[0]
         cleaned_answer = answer.strip()


### PR DESCRIPTION
max_new_tokens is added as a parameter to answer_question() and default is set to 256 instead of 512.
**Reasons:** 
* In order to reduce the delay when the model enters in loops generating .............. and taking a lot of time (I found such cases with images with text) and to control it.
* In test generations I found about 200 was enough for complete text (probably less), but 100 was a bit short.

Also, for avoiding the repetition loops, can some sort of an interrupt be added, as a callback like in GPT4All and a constraint when capturing repetition of tokens, unusual sequences like these dots etc.: repetition_penalty etc.? Also: a streaming mode? (I had a glance on the code, I may try to figure it out.)

Sample repetition loop:
Z:\LMSYS-Free-GPT4-Claude-15-4-2024-2024-04-15_18-33-46.mp4_snapshot_05.28.266.png

The image is a screenshot of a website called "LMSys Chatbot Arena". The website is predominantly white with blue and orange accents. The main focus is a banner at the top of the screen, which is white with red and blue text. The text reads "Free GPT4, claude, llama, code llama, mixral-of-experts, command-r-plus..........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

The picture itself had "..." in the text.