### PR TITLE
GGML implementation updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "vik launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/moondream-ggml/core/build/moondream_ggml_exe",
+            "args": [
+                "${workspaceFolder}/moondream-ggml/data/"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "files.associations": {
+        "__availability": "c",
+        "cstdarg": "c",
+        "cwchar": "c",
+        "__config": "cpp",
+        "__verbose_abort": "cpp",
+        "charconv": "cpp",
+        "cstdio": "cpp",
+        "ctime": "cpp",
+        "filesystem": "cpp",
+        "format": "cpp",
+        "locale": "cpp",
+        "regex": "cpp",
+        "vector": "cpp",
+        "version": "cpp"
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.0.0",
+    "options": {
+        "cwd": "${workspaceRoot}/moondream-ggml/core/build"
+    },
+    "tasks": [
+        {
+            "label": "cmake",
+            "command": "cmake -G 'Unix Makefiles' -DGGML_METAL=off -DCMAKE_BUILD_TYPE=Debug - ..",
+            "type": "shell",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "make",
+            "command": "make",
+            "type": "shell",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "panel": "shared"
+            },
+        }
+    ]
+}

--- a/Scratchpad.ipynb
+++ b/Scratchpad.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/vikhyat/Coding/moondream/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "import torch\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "from moondream.modeling_phi import apply_rotary_pos_emb\n",
+    "\n",
+    "model_id = \"vikhyatk/moondream2\"\n",
+    "revision = \"2024-04-02\"\n",
+    "model = AutoModelForCausalLM.from_pretrained(\n",
+    "    model_id, trust_remote_code=True, revision=revision, torch_dtype=torch.float16\n",
+    ")\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokens = tokenizer(\"Describe the image.\", return_tensors=\"pt\")['input_ids']\n",
+    "inputs_embeds = model.text_model.get_input_embeddings()(tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([1, 5, 2048])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[ 0.1456,  0.5635,  0.6240,  ...,  0.4666,  0.2549, -0.2764],\n",
+       "         [ 0.6284,  0.3845,  0.8750,  ...,  0.9077,  0.0452, -0.3027],\n",
+       "         [ 0.3618,  0.6597,  0.6064,  ...,  0.4902,  0.1268, -0.3398],\n",
+       "         [ 0.1552,  0.3916,  0.4509,  ...,  0.1307, -0.0458, -0.0320],\n",
+       "         [ 0.0200,  0.0423, -0.5195,  ...,  0.1262,  0.0666, -0.0076]]],\n",
+       "       dtype=torch.float16, grad_fn=<ViewBackward0>)"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = inputs_embeds\n",
+    "x = model.text_model.transformer.h[0].ln(x)\n",
+    "\n",
+    "# Attention\n",
+    "mixer = model.text_model.transformer.h[0].mixer\n",
+    "bsz, q_len, _ = x.size()\n",
+    "query_states, key_states, value_states = mixer.Wqkv(x).chunk(3, dim=-1)\n",
+    "query_states = query_states.view(\n",
+    "    bsz, q_len, mixer.num_heads, mixer.head_dim\n",
+    ").transpose(1, 2)\n",
+    "key_states = key_states.view(\n",
+    "    bsz, q_len, mixer.num_key_value_heads, mixer.head_dim\n",
+    ").transpose(1, 2)\n",
+    "value_states = value_states.view(\n",
+    "    bsz, q_len, mixer.num_key_value_heads, mixer.head_dim\n",
+    ").transpose(1, 2)\n",
+    "\n",
+    "# rope\n",
+    "kv_seq_len = key_states.shape[-2]\n",
+    "cos, sin = mixer.rotary_emb(value_states, seq_len=kv_seq_len)\n",
+    "query_rot, query_pass = (\n",
+    "    query_states[..., : mixer.rotary_emb.dim],\n",
+    "    query_states[..., mixer.rotary_emb.dim :],\n",
+    ")\n",
+    "key_rot, key_pass = (\n",
+    "    key_states[..., : mixer.rotary_emb.dim],\n",
+    "    key_states[..., mixer.rotary_emb.dim :],\n",
+    ")\n",
+    "query_rot, key_rot = apply_rotary_pos_emb(\n",
+    "    query_rot, key_rot, cos, sin, None\n",
+    ")\n",
+    "query_states = torch.cat((query_rot, query_pass), dim=-1)\n",
+    "key_states = torch.cat((key_rot, key_pass), dim=-1)\n",
+    "\n",
+    "attn_output = scaled_dot_product_attention(\n",
+    "    query_states, key_states, value_states, is_causal=True\n",
+    ")\n",
+    "attn_output = attn_output.transpose(1, 2).contiguous()\n",
+    "attn_output = attn_output.reshape(bsz, q_len, mixer.hidden_size)\n",
+    "attn_output = mixer.out_proj(attn_output)\n",
+    "\n",
+    "print(attn_output.shape)\n",
+    "attn_output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None) -> torch.Tensor:\n",
+    "    L, S = query.size(-2), key.size(-2)\n",
+    "    scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale\n",
+    "    attn_bias = torch.zeros(L, S, dtype=query.dtype)\n",
+    "    if is_causal:\n",
+    "        assert attn_mask is None\n",
+    "        temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)\n",
+    "        attn_bias.masked_fill_(temp_mask.logical_not(), float(\"-inf\"))\n",
+    "        attn_bias.to(query.dtype)\n",
+    "\n",
+    "    if attn_mask is not None:\n",
+    "        if attn_mask.dtype == torch.bool:\n",
+    "            attn_bias.masked_fill_(attn_mask.logical_not(), float(\"-inf\"))\n",
+    "        else:\n",
+    "            attn_bias += attn_mask\n",
+    "    attn_weight = query @ key.transpose(-2, -1) * scale_factor\n",
+    "    attn_weight += attn_bias\n",
+    "    attn_weight = torch.softmax(attn_weight, dim=-1)\n",
+    "    attn_weight = torch.dropout(attn_weight, dropout_p, train=True)\n",
+    "    return attn_weight @ value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Question: Is this a dog? Yes or no.\\n\\nAnswer: No\\n\\n4. Is this a cat or a dog? No\\n\\n5. Is this a cat or a dog? No\\n\\n6. Is'"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tokens = tokenizer(\"Question: Is this a dog? Yes or no.\\n\\nAnswer:\", return_tensors=\"pt\")['input_ids']\n",
+    "output = model.text_model.generate(tokens, do_sample=False, max_length=50, pad_token_id=tokenizer.eos_token_id)\n",
+    "tokenizer.decode(output[0], skip_special_tokens=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/moondream-ggml/core/src/moondream.cpp
+++ b/moondream-ggml/core/src/moondream.cpp
@@ -329,18 +329,15 @@ static void log_tensor(ggml_tensor * dst, const ggml_tensor * src, int ith, int 
 
     printf("Shape: %lld %lld %lld %lld\n", dst->ne[3], dst->ne[2], dst->ne[1], dst->ne[0]);
     switch (dst->type) {
-        case GGML_TYPE_F16: {
+        case GGML_TYPE_F16:
             printf("Type: f16\n");
             break;
-        }
-        case GGML_TYPE_F32: {
+        case GGML_TYPE_F32:
             printf("Type: f32\n");
             break;
-        }
-        default: {
+        default:
             printf("Type: unknown\n");
             break;
-        }
     }
 
     // emit last 2 dimension values
@@ -659,7 +656,6 @@ ggml_cgraph * build_phi2(
     const int64_t n_layer = hparams.n_layer;
     const int64_t n_embd = hparams.n_embd;
     const int64_t n_embd_head = hparams.n_embd_head_v;
-    const int64_t n_embd_gqa = hparams.n_embd;
     GGML_ASSERT(n_embd_head == hparams.n_embd_head_k);
 
     const uint32_t n_ctx_orig = cparams.n_ctx_orig_yarn;
@@ -689,6 +685,7 @@ ggml_cgraph * build_phi2(
         );
         moondream_set_tensor_name(attn_norm_output, "attn_norm", il);
 
+
         // Self-attention
         {
             struct ggml_tensor * q_cur = nullptr;
@@ -704,13 +701,10 @@ ggml_cgraph * build_phi2(
                 ctx0, ggml_view_2d(ctx0, cur, n_embd, n_tokens, cur->nb[1], 0*sizeof(float)*(n_embd))
             );
             k_cur = ggml_cont(
-                ctx0, ggml_view_2d(ctx0, cur, n_embd_gqa, n_tokens, cur->nb[1], 1*sizeof(float)*(n_embd))
+                ctx0, ggml_view_2d(ctx0, cur, n_embd, n_tokens, cur->nb[1], 1*sizeof(float)*(n_embd))
             );
             v_cur = ggml_cont(
-                ctx0, 
-                ggml_view_2d(
-                    ctx0, cur, n_embd_gqa, n_tokens, cur->nb[1], 1*sizeof(float)*(n_embd + n_embd_gqa)
-                )
+                ctx0, ggml_view_2d(ctx0, cur, n_embd, n_tokens, cur->nb[1], 2*sizeof(float)*(n_embd))
             );
   
             moondream_set_tensor_name(q_cur, "q_cur", il);
@@ -2074,7 +2068,7 @@ int main(int argc, char * argv[]) {
     
     /* Start of prompt tokenization. */
     //const char * prompt = "<image>\n\nQuestion: Describe the image.\n\nAnswer:";
-    const char * prompt = "Describe the image.";
+    const char * prompt = "Question: Is this a dog? Yes or no.\n\nAnswer:";
     size_t prompt_len = strlen(prompt);
     printf("prompt_len: %zu\n", prompt_len);
     int32_t token_ids[prompt_len];

--- a/moondream-ggml/core/src/moondream.cpp
+++ b/moondream-ggml/core/src/moondream.cpp
@@ -39,21 +39,6 @@ static double bytes_to_gib(size_t n_bytes) {
     return static_cast<double>(n_bytes) / (1024.0 * 1024.0 * 1024.0);
 }
 
-static std::string format(const char * fmt, ...) {
-    va_list ap;
-    va_list ap2;
-    va_start(ap, fmt);
-    va_copy(ap2, ap);
-    int size = vsnprintf(NULL, 0, fmt, ap);
-    GGML_ASSERT(size >= 0 && size < INT_MAX); // NOLINT
-    std::vector<char> buf(size + 1);
-    int size2 = vsnprintf(buf.data(), size + 1, fmt, ap2);
-    GGML_ASSERT(size2 == size);
-    va_end(ap2);
-    va_end(ap);
-    return std::string(buf.data(), size);
-}
-
 static void moondream_set_tensor_name(ggml_tensor * cur, const char * name, int il) {
     if (il >= 0) {
         ggml_format_name(cur, "%s-%d", name, il);
@@ -1975,11 +1960,7 @@ static std::string moondream_decode_token_str(const std::string & text) {
         try {
             decoded_text += unicode_utf8_to_byte(utf8);
         } catch (const std::out_of_range & /*e*/) {
-            decoded_text += "[UNK_BYTE_0x";
-            for (const auto c : utf8) {
-                decoded_text += format("%02x", (uint8_t) c);
-            }
-            decoded_text += text + "]";
+            decoded_text += "[UNK]";
         }
     }
     return decoded_text;
@@ -2103,7 +2084,7 @@ int main(int argc, char * argv[]) {
     
     /* Start of prompt tokenization. */
     //const char * prompt = "<image>\n\nQuestion: Describe the image.\n\nAnswer:";
-    const char * prompt = "Question: Describe the image.\n\nAnswer:";
+    const char * prompt = "Describe the image.";
     size_t prompt_len = strlen(prompt);
     printf("prompt_len: %zu\n", prompt_len);
     int32_t token_ids[prompt_len];

--- a/moondream-ggml/core/src/moondream.cpp
+++ b/moondream-ggml/core/src/moondream.cpp
@@ -1957,11 +1957,10 @@ bool moondream_lm_set_inputs(moondream_lm_context & mctx, moondream_lm_batch & b
     uint32_t n_kv = mctx.kv_cache.n;
     float * inp_kq_mask_data = (float *)mctx.inp_kq_mask->data;
     for (int i = 0; i < batch.n_tokens; ++i) {
-        //int32_t cur_pos = batch.pos[i];
+        int32_t cur_pos = batch.pos[i];
         for (int k = 0; k < n_kv; ++k) {
-            // TODO: figure out correct stride for -INFINITY entries.
-            //float f = (k > cur_pos) ? -INFINITY : 0.0f;
-            inp_kq_mask_data[(i * n_kv) + k] = 0.0f;
+            float f = (k > cur_pos) ? -INFINITY : 0.0f;
+            inp_kq_mask_data[(i * n_kv) + k] = f;
         }
     }
 

--- a/moondream-ggml/core/src/moondream.cpp
+++ b/moondream-ggml/core/src/moondream.cpp
@@ -168,7 +168,7 @@ struct moondream_lm_hparams {
     int n_ff;
     int n_layer;
     int n_rot;
-    int n_ctx_train;
+    uint32_t n_ctx_train;
     int n_head;
     int n_head_kv;
     int n_embd_head_k;


### PR DESCRIPTION
Pushing my updates to the GGML implementation to this branch.

Changes made so far:

1. Added `log_tensor` for use with `ggml_map_custom1_inplace` to help with comparing tensors between the GGML and PyTorch implementation.
2. Simplified `build_phi2` implementation.