### PR TITLE
Cmake build fixes

### DIFF
--- a/moondream-ggml/.gitignore
+++ b/moondream-ggml/.gitignore
@@ -1,2 +1,3 @@
 build/
 .cache/
+*.egg-info/

--- a/moondream-ggml/README.md
+++ b/moondream-ggml/README.md
@@ -44,8 +44,7 @@ cd core
 bash scripts/cppcheck.sh
 ```
 
-## Debugging
-To build in debug mode, add the -DDEBUG_MODE=ON flag when calling cmake.
-```
-cmake -DDEBUG_BUILD=ON ..
-```
+## CMake Build Options
+- `-DDEBUG_BUILD=`, default: `OFF`, description: adds debug symbols when `ON`
+- `-DMOONDREAM_SHARED_LIBS=`, default `OFF`, description: builds shared libraries when `ON`
+- `-DMOONDREAM_EXE=`, default `off`, description: builds standalone executable instead of library when `ON`

--- a/moondream-ggml/README.md
+++ b/moondream-ggml/README.md
@@ -7,7 +7,7 @@ Moondream inference with GGML (work in progress).
 - c++11 capable compiler
 - ggml (comes packaged in this repo)
 
-## Instructions
+## Standalone Executable Instructions 
 0. Make sure there is a directory called `data` one level above this one (i.e. `../data/`),
 and make sure it contains the moondream2 gguf files
 (`moondream2-text-model-f16.gguf` and `moondream2-mmproj-f16.gguf`, obtained 
@@ -23,7 +23,7 @@ mkdir build && cd build
 ```
 3. Generate makefile with cmake.
 ```
-cmake -DDEBUG_BUILD=OFF ..
+cmake -DDEBUG_BUILD=OFF -DMOONDREAM_EXE=ON ..
 ```
 4. Build with make.
 ```
@@ -31,7 +31,7 @@ make
 ```
 5. Run executable with data path argument.
 ```
-./moondream_ggml_exe ../../../data/
+./moondream_ggml ../../../data/
 ```
 
 ## Static Analysis

--- a/moondream-ggml/bindings/python/setup.py
+++ b/moondream-ggml/bindings/python/setup.py
@@ -10,14 +10,13 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 
 class CMakeBuildExt(build_ext):
     def build_extensions(self):
-        # First, configure CMake build.
         import platform
         import sys
         import sysconfig
-
         import pybind11
-
+        
         # Work out the relevant Python paths to pass to CMake.
+        ext = self.extensions[0]
         if platform.system() == "Windows":
             cmake_python_library = "{}/libs/python{}.lib".format(
                 sysconfig.get_config_var("prefix"),
@@ -34,21 +33,27 @@ class CMakeBuildExt(build_ext):
                 sysconfig.get_config_var("INSTSONAME"),
             )
         cmake_python_include_dir = sysconfig.get_path("include")
-
-        install_dir = os.path.abspath(
-            os.path.dirname(self.get_ext_fullpath("dummy"))
+        
+        #install_dir = os.path.abspath(
+        #    os.path.dirname(self.get_ext_fullpath("dummy"))
+        #)
+        #os.makedirs(install_dir, exist_ok=True)
+        
+        ext_dir = os.path.abspath(
+            os.path.dirname(self.get_ext_fullpath(ext.name))
         )
-        os.makedirs(install_dir, exist_ok=True)
+        os.makedirs(ext_dir, exist_ok=True)
         cmake_args = [
-            "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
-            #"-DCMAKE_CUDA_STANDARD=17",
+            "-DCMAKE_INSTALL_PREFIX={}".format(ext_dir),
+            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE={}".format(ext_dir), 
             "-DPython_EXECUTABLE={}".format(sys.executable),
             "-DPython_LIBRARIES={}".format(cmake_python_library),
             "-DPython_INCLUDE_DIRS={}".format(cmake_python_include_dir),
-            "-DCMAKE_BUILD_TYPE={}".format(
-                "Debug" if self.debug else "Release"
-            ),
+            "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_PREFIX_PATH={}".format(pybind11.get_cmake_dir()),
+            "-DDEBUG_BUILD=OFF",
+            "-DMOONDREAM_SHARED_LIBS=ON",
+            "-DMOONDREAM_EXE=OFF",
             "-G Unix Makefiles",
         ]
         os.makedirs(self.build_temp, exist_ok=True)
@@ -78,7 +83,7 @@ extensions = [
 
 setup(
     name="moondream-ggml",
-    author="managerial accounting",
+    author="M87 Labs",
     package_dir={"": "."},
     packages=find_packages("."),
     include_package_data=True,

--- a/moondream-ggml/core/CMakeLists.txt
+++ b/moondream-ggml/core/CMakeLists.txt
@@ -3,6 +3,7 @@ project(moondream_ggml)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 option(DEBUG_BUILD "Build with debug flags" OFF)
 option(MOONDREAM_SHARED_LIBS "Build shared libraries" OFF)
@@ -20,7 +21,6 @@ if(NOT MOONDREAM_SHARED_LIBS)
     set(GGML_STATIC ON)
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build ggml as a static library" FORCE)
 endif()
-set(GGML_METAL OFF)
 add_subdirectory(./dependencies/ggml)
 
 set(SOURCES 

--- a/moondream-ggml/core/CMakeLists.txt
+++ b/moondream-ggml/core/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 option(DEBUG_BUILD "Build with debug flags" OFF)
+option(MOONDREAM_SHARED_LIBS "Build shared libraries" OFF)
+option(MOONDREAM_EXE "Build executable instead of library" OFF)
 
 if(DEBUG_BUILD)
     set(CMAKE_BUILD_TYPE Debug)
@@ -14,9 +16,11 @@ else()
     message("CMAKE_BUILD_TYPE=Release")
 endif()
 
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build ggml as a static library" FORCE)
+if(NOT MOONDREAM_SHARED_LIBS)
+    set(GGML_STATIC ON)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build ggml as a static library" FORCE)
+endif()
 add_subdirectory(./dependencies/ggml)
-
 
 set(SOURCES 
     src/moondream.cpp
@@ -28,21 +32,18 @@ set(SOURCES
     src/unicode.cpp
 )
 
-# Library target.
-add_library(moondream_ggml STATIC ${SOURCES})
+if(MOONDREAM_EXE)
+    add_executable(moondream_ggml ${SOURCES})
+else()
+    if(MOONDREAM_SHARED_LIBS)
+        add_library(moondream_ggml SHARED ${SOURCES})
+    else()
+        add_library(moondream_ggml STATIC ${SOURCES})
+    endif()
+    # Define MOONDREAM_LIBRARY_BUILD in order to exclude main function.
+    target_compile_definitions(moondream_ggml PRIVATE MOONDREAM_LIBRARY_BUILD)
+endif()
+
 target_link_libraries(moondream_ggml PRIVATE ggml)
 target_include_directories(moondream_ggml PRIVATE ./dependencies/ggml/include)
 target_include_directories(moondream_ggml PRIVATE ./dependencies/single_header/include)
-# Define MOONDREAM_LIBRARY_BUILD in order to exclude main function.
-target_compile_definitions(moondream_ggml PRIVATE MOONDREAM_LIBRARY_BUILD)
-
-# Executable target.
-add_executable(moondream_ggml_exe ${SOURCES})
-target_link_libraries(moondream_ggml_exe PRIVATE ggml)
-target_include_directories(moondream_ggml_exe PRIVATE ./dependencies/ggml/include)
-target_include_directories(moondream_ggml_exe PRIVATE ./dependencies/single_header/include)
-
-if(DEBUG_BUILD)
-    target_compile_options(moondream_ggml PRIVATE -g)
-    target_compile_options(moondream_ggml_exe PRIVATE -g)
-endif()

--- a/moondream-ggml/core/CMakeLists.txt
+++ b/moondream-ggml/core/CMakeLists.txt
@@ -20,6 +20,7 @@ if(NOT MOONDREAM_SHARED_LIBS)
     set(GGML_STATIC ON)
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build ggml as a static library" FORCE)
 endif()
+set(GGML_METAL OFF)
 add_subdirectory(./dependencies/ggml)
 
 set(SOURCES 


### PR DESCRIPTION
I originally developed the python package alongside a nix derivation (`./moondream-ggml/moondream-ggml-python.nix`) for installation. The nix installation worked but I never tested it with pip. Today I tried to install with pip for the first time and I ran into some issues. This fixes them. I'm pretty sure I broke the nix installation though.

The main problem was non position independent code. Since `libggml` and `libmoondream_ggml` were built as static libraries, they contained position dependent code which cause problems when they were linked to the `cpp_ffi` shared library. I added an option for building `libggml` and `libmoondream_ggml` as shared libraries in order to resolve this. I'm not sure why this was only an issue with the pip install. Maybe because of different gcc versions?

I also encountered some problems with SIMD support because I did all of this in a VirtualBox VM. In my case the solution was manually setting `-DGGML_FMA=ON` but there will likely be different problems/solutions in different environments. We'll probably need some additional configuration code in `./moondream-ggml/bindings/python/setup.py` in order to detect architecture/SIMD support and set the appropriate GGML build flags.