### PR TITLE
Fix NameError in moondream.py

### DIFF
--- a/moondream/moondream.py
+++ b/moondream/moondream.py
@@ -93,7 +93,7 @@ class Moondream(PreTrainedModel):
         tokenizer,
         chat_history="",        
         result_queue=None,        
-        max_new_tokens=256
+        max_new_tokens=256,
         **kwargs,
     ):
         prompt = f"<image>\n\n{chat_history}Question: {question}\n\nAnswer:"


### PR DESCRIPTION
A small follow-up to #86. Currently, running  anything that depends on `moondream.py` results in `NameError: name 'kwargs' is not defined`, due to a missing comma in `answer_question`'s arg list.