### PR TITLE
Use pyvips for image resizing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pip install -r requirements.txt
+    - name: Run tests
+      run: |
+        python -m pytest tests/test_image_crops.py -v

--- a/moondream/torch/image_crops.py
+++ b/moondream/torch/image_crops.py
@@ -109,25 +109,29 @@ def overlap_crop_image(
     )
 
     # Convert to vips for resizing
-    vips_image = pyvips.Image.new_from_memory(image.tobytes(), 
-                                            image.shape[1], image.shape[0], 
-                                            image.shape[2], 'uchar')
-    
+    vips_image = pyvips.Image.new_from_memory(
+        image.tobytes(), image.shape[1], image.shape[0], image.shape[2], "uchar"
+    )
+
     # Resize using vips
     scale_x = target_size[1] / image.shape[1]
     scale_y = target_size[0] / image.shape[0]
     resized = vips_image.resize(scale_x, vscale=scale_y)
-    image = np.ndarray(buffer=resized.write_to_memory(),
-                      dtype=np.uint8,
-                      shape=[resized.height, resized.width, resized.bands])
+    image = np.ndarray(
+        buffer=resized.write_to_memory(),
+        dtype=np.uint8,
+        shape=[resized.height, resized.width, resized.bands],
+    )
 
     # Create global crop
     scale_x = base_size[1] / vips_image.width
     scale_y = base_size[0] / vips_image.height
     global_vips = vips_image.resize(scale_x, vscale=scale_y)
-    global_crop = np.ndarray(buffer=global_vips.write_to_memory(),
-                          dtype=np.uint8,
-                          shape=[global_vips.height, global_vips.width, global_vips.bands])
+    global_crop = np.ndarray(
+        buffer=global_vips.write_to_memory(),
+        dtype=np.uint8,
+        shape=[global_vips.height, global_vips.width, global_vips.bands],
+    )
 
     # Extract crops with overlap
     crops = []

--- a/moondream/torch/image_crops.py
+++ b/moondream/torch/image_crops.py
@@ -1,9 +1,9 @@
 import math
 import numpy as np
 import torch
+import pyvips
 
 from typing import TypedDict
-from PIL import Image
 
 
 def select_tiling(
@@ -108,18 +108,26 @@ def overlap_crop_image(
         tiling[1] * crop_window_size + total_margin_pixels,
     )
 
-    # Convert to PIL for resizing
-    pil_image = Image.fromarray(image)
-    resized = pil_image.resize(
-        (target_size[1], target_size[0]), Image.Resampling.LANCZOS
-    )
-    image = np.array(resized)
+    # Convert to vips for resizing
+    vips_image = pyvips.Image.new_from_memory(image.tobytes(), 
+                                            image.shape[1], image.shape[0], 
+                                            image.shape[2], 'uchar')
+    
+    # Resize using vips
+    scale_x = target_size[1] / image.shape[1]
+    scale_y = target_size[0] / image.shape[0]
+    resized = vips_image.resize(scale_x, vscale=scale_y)
+    image = np.ndarray(buffer=resized.write_to_memory(),
+                      dtype=np.uint8,
+                      shape=[resized.height, resized.width, resized.bands])
 
     # Create global crop
-    global_pil = pil_image.resize(
-        (base_size[1], base_size[0]), Image.Resampling.LANCZOS
-    )  # PIL uses (width, height)
-    global_crop = np.array(global_pil)
+    scale_x = base_size[1] / vips_image.width
+    scale_y = base_size[0] / vips_image.height
+    global_vips = vips_image.resize(scale_x, vscale=scale_y)
+    global_crop = np.ndarray(buffer=global_vips.write_to_memory(),
+                          dtype=np.uint8,
+                          shape=[global_vips.height, global_vips.width, global_vips.bands])
 
     # Extract crops with overlap
     crops = []

--- a/moondream/torch/image_crops.py
+++ b/moondream/torch/image_crops.py
@@ -109,29 +109,19 @@ def overlap_crop_image(
     )
 
     # Convert to vips for resizing
-    vips_image = pyvips.Image.new_from_memory(
-        image.tobytes(), image.shape[1], image.shape[0], image.shape[2], "uchar"
-    )
+    vips_image = pyvips.Image.new_from_array(image)
 
     # Resize using vips
     scale_x = target_size[1] / image.shape[1]
     scale_y = target_size[0] / image.shape[0]
     resized = vips_image.resize(scale_x, vscale=scale_y)
-    image = np.ndarray(
-        buffer=resized.write_to_memory(),
-        dtype=np.uint8,
-        shape=[resized.height, resized.width, resized.bands],
-    )
+    image = resized.numpy()
 
     # Create global crop
     scale_x = base_size[1] / vips_image.width
     scale_y = base_size[0] / vips_image.height
     global_vips = vips_image.resize(scale_x, vscale=scale_y)
-    global_crop = np.ndarray(
-        buffer=global_vips.write_to_memory(),
-        dtype=np.uint8,
-        shape=[global_vips.height, global_vips.width, global_vips.bands],
-    )
+    global_crop = global_vips.numpy()
 
     # Extract crops with overlap
     crops = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 accelerate==0.32.1
 huggingface-hub==0.24.0
 Pillow==10.4.0
+pyvips-binary==8.16.0
 pyvips==2.2.3
 torch==2.3.1
 torchvision==0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 accelerate==0.32.1
 huggingface-hub==0.24.0
 Pillow==10.4.0
+pyvips==2.2.3
 torch==2.3.1
 torchvision==0.18.1
 transformers==4.44.0

--- a/tests/test_image_crops.py
+++ b/tests/test_image_crops.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 from moondream.torch.image_crops import overlap_crop_image, reconstruct_from_crops
 
+
 def test_overlap_crop_basic():
     # Create a test image
     test_image = np.zeros((800, 600, 3), dtype=np.uint8)
@@ -16,15 +17,17 @@ def test_overlap_crop_basic():
     assert all(crop.shape == (378, 378, 3) for crop in result["local_crops"])
     assert len(result["tiling"]) == 2
 
+
 def test_overlap_crop_small_image():
     # Test with image smaller than crop size
     test_image = np.zeros((300, 200, 3), dtype=np.uint8)
     result = overlap_crop_image(test_image, overlap_margin=4, max_crops=12)
-    
+
     # Should still produce valid output
     assert result["global_crop"].shape == (378, 378, 3)
     assert len(result["local_crops"]) == 1
     assert result["tiling"] == (1, 1)
+
 
 def test_reconstruction():
     # Create a test image
@@ -35,7 +38,9 @@ def test_reconstruction():
     # Crop and reconstruct
     result = overlap_crop_image(test_image, overlap_margin=4, max_crops=12)
     crops_tensor = [torch.from_numpy(crop) for crop in result["local_crops"]]
-    reconstructed = reconstruct_from_crops(crops_tensor, result["tiling"], overlap_margin=4)
+    reconstructed = reconstruct_from_crops(
+        crops_tensor, result["tiling"], overlap_margin=4
+    )
 
     # Convert back to numpy for comparison
     reconstructed_np = reconstructed.numpy()
@@ -45,9 +50,9 @@ def test_reconstruction():
     # but the white rectangle should still be visible in the middle
     center_original = test_image[300:500, 200:400].mean()
     center_reconstructed = reconstructed_np[
-        reconstructed_np.shape[0]//2-100:reconstructed_np.shape[0]//2+100,
-        reconstructed_np.shape[1]//2-100:reconstructed_np.shape[1]//2+100
+        reconstructed_np.shape[0] // 2 - 100 : reconstructed_np.shape[0] // 2 + 100,
+        reconstructed_np.shape[1] // 2 - 100 : reconstructed_np.shape[1] // 2 + 100,
     ].mean()
-    
+
     # The center region should be significantly brighter than the edges
     assert center_reconstructed > reconstructed_np[:100, :100].mean() + 100

--- a/tests/test_image_crops.py
+++ b/tests/test_image_crops.py
@@ -1,0 +1,53 @@
+import numpy as np
+import torch
+from moondream.torch.image_crops import overlap_crop_image, reconstruct_from_crops
+
+def test_overlap_crop_basic():
+    # Create a test image
+    test_image = np.zeros((800, 600, 3), dtype=np.uint8)
+    # Add a recognizable pattern - white rectangle in the middle
+    test_image[300:500, 200:400] = 255
+
+    result = overlap_crop_image(test_image, overlap_margin=4, max_crops=12)
+
+    # Check basic properties
+    assert result["global_crop"].shape == (378, 378, 3)
+    assert len(result["local_crops"]) > 0
+    assert all(crop.shape == (378, 378, 3) for crop in result["local_crops"])
+    assert len(result["tiling"]) == 2
+
+def test_overlap_crop_small_image():
+    # Test with image smaller than crop size
+    test_image = np.zeros((300, 200, 3), dtype=np.uint8)
+    result = overlap_crop_image(test_image, overlap_margin=4, max_crops=12)
+    
+    # Should still produce valid output
+    assert result["global_crop"].shape == (378, 378, 3)
+    assert len(result["local_crops"]) == 1
+    assert result["tiling"] == (1, 1)
+
+def test_reconstruction():
+    # Create a test image
+    test_image = np.zeros((800, 600, 3), dtype=np.uint8)
+    # Add a recognizable pattern
+    test_image[300:500, 200:400] = 255
+
+    # Crop and reconstruct
+    result = overlap_crop_image(test_image, overlap_margin=4, max_crops=12)
+    crops_tensor = [torch.from_numpy(crop) for crop in result["local_crops"]]
+    reconstructed = reconstruct_from_crops(crops_tensor, result["tiling"], overlap_margin=4)
+
+    # Convert back to numpy for comparison
+    reconstructed_np = reconstructed.numpy()
+
+    # The reconstructed image should be similar to the input
+    # We can't expect exact equality due to resizing operations
+    # but the white rectangle should still be visible in the middle
+    center_original = test_image[300:500, 200:400].mean()
+    center_reconstructed = reconstructed_np[
+        reconstructed_np.shape[0]//2-100:reconstructed_np.shape[0]//2+100,
+        reconstructed_np.shape[1]//2-100:reconstructed_np.shape[1]//2+100
+    ].mean()
+    
+    # The center region should be significantly brighter than the edges
+    assert center_reconstructed > reconstructed_np[:100, :100].mean() + 100


### PR DESCRIPTION
This PR:

1. Updates requirements.txt to use pyvips-binary instead of system libvips
2. Adds unit tests for image_crops.py
3. Adds GitHub workflow to run tests

The changes ensure that:
- No system-level libvips installation is required
- Image cropping functionality is verified through tests
- Tests run automatically on PRs and pushes to main