### PR TITLE
further optimize vision encoder implementation

### DIFF
--- a/moondream/torch/config.py
+++ b/moondream/torch/config.py
@@ -19,6 +19,8 @@ class VisionConfig:
     enc_n_heads: int = 16
     crop_size: int = 378
     in_channels: int = 3
+    max_crops: int = 12
+    overlap_margin: int = 4
 
 
 @dataclass(frozen=True)

--- a/moondream/torch/vision.py
+++ b/moondream/torch/vision.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as F
 import numpy as np
 
+from typing import Union, Tuple
 from einops import rearrange
 from PIL import Image
 
@@ -20,39 +21,23 @@ else:
     adaptive_avg_pool2d = F.adaptive_avg_pool2d
 
 
-def encode_image(
-    image: Image.Image, weights: VisionModel, config: VisionConfig
-) -> torch.Tensor:
+def prepare_crops(
+    image: Image.Image, config: VisionConfig, device: Union[str, torch.device, int]
+) -> Tuple[torch.Tensor, Tuple[int, int]]:
     np_image = np.array(image.convert("RGB"))
-    crops = overlap_crop_image(np_image, max_crops=12, overlap_margin=4)
-    all_crops = np.stack([crops["global_crop"], *crops["local_crops"]], axis=0)
+    overlap_crops = overlap_crop_image(
+        np_image, max_crops=config.max_crops, overlap_margin=config.overlap_margin
+    )
+    all_crops = overlap_crops["crops"]
     all_crops = np.transpose(all_crops, (0, 3, 1, 2))
     all_crops = (
         torch.from_numpy(all_crops)
-        .to(device=weights.pos_emb.device, dtype=torch.float16)
+        .to(device=device, dtype=torch.float16)
         .div_(255.0)
         .sub_(0.5)
         .div_(0.5)
     )
-
-    outputs = vision_encoder(all_crops, weights, config)
-
-    global_features = outputs[0]
-    local_features = outputs[1:].view(-1, 27, 27, 1152)
-
-    reconstructed = reconstruct_from_crops(
-        local_features,
-        crops["tiling"],
-        patch_size=1,
-        overlap_margin=4,
-    )
-
-    reconstructed = reconstructed.permute(2, 0, 1)
-    reconstructed = adaptive_avg_pool2d(reconstructed, output_size=(27, 27))
-    reconstructed = reconstructed.permute(1, 2, 0).view(729, 1152)
-    final_features = torch.cat([global_features, reconstructed], dim=-1)
-
-    return mlp(final_features, weights.proj_mlp)
+    return all_crops, overlap_crops["tiling"]
 
 
 def vision_encoder(input_BCHW: torch.Tensor, w: VisionModel, config: VisionConfig):
@@ -71,3 +56,33 @@ def vision_encoder(input_BCHW: torch.Tensor, w: VisionModel, config: VisionConfi
     x = layer_norm(x, w.post_ln)
 
     return x
+
+
+def vision_projection(
+    global_features: torch.Tensor, reconstructed: torch.Tensor, w: VisionModel
+):
+    reconstructed = reconstructed.permute(2, 0, 1)
+    reconstructed = adaptive_avg_pool2d(reconstructed, output_size=(27, 27))
+    reconstructed = reconstructed.permute(1, 2, 0).view(729, 1152)
+    final_features = torch.cat([global_features, reconstructed], dim=-1)
+    return mlp(final_features, w.proj_mlp)
+
+
+def encode_image(
+    image: Image.Image, weights: VisionModel, config: VisionConfig
+) -> torch.Tensor:
+    # This is split into sub-functions to allow sections to be compiled without
+    # graph breaks, which is needed if we want to enable reduce-overhead mode.
+    # `vision_encoder` and `vision_projection` can be compiled if needed.
+
+    all_crops, tiling = prepare_crops(image, config, device=weights.pos_emb.device)
+
+    outputs = vision_encoder(all_crops, weights, config)
+
+    global_features = outputs[0]
+    local_features = outputs[1:].view(-1, 27, 27, 1152)
+    reconstructed = reconstruct_from_crops(
+        local_features, tiling, patch_size=1, overlap_margin=config.overlap_margin
+    )
+
+    return vision_projection(global_features, reconstructed, weights)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #190
* __->__ #189
* #188

1. pre-allocate memory for crops to avoid unnecessary data copying
2. break up vision encoder implementation into torch.compile-able parts