### PR TITLE
remove einops ops as it breaks executorch

### DIFF
--- a/moondream/torch/vision.py
+++ b/moondream/torch/vision.py
@@ -4,7 +4,6 @@ import torch.nn.functional as F
 import numpy as np
 
 from typing import Union, Tuple
-from einops import rearrange
 from PIL import Image
 
 from .layers import attn, layer_norm, linear, mlp

--- a/moondream/torch/vision.py
+++ b/moondream/torch/vision.py
@@ -61,6 +61,7 @@ def rearrange_einops_to_torch(x, patch_size):
 
     return x
 
+
 def vision_encoder(input_BCHW: torch.Tensor, w: nn.Module, config: VisionConfig):
     x = rearrange_einops_to_torch(input_BCHW, config.enc_patch_size)
 

--- a/moondream/torch/vision.py
+++ b/moondream/torch/vision.py
@@ -41,7 +41,7 @@ def prepare_crops(
     return all_crops, overlap_crops["tiling"]
 
 
-def rearrange_einops_to_torch(x, patch_size):
+def create_patches(x, patch_size):
     # Original shape: [B, C, H, W]
     B, C, H, W = x.shape
     P1 = P2 = patch_size
@@ -62,7 +62,7 @@ def rearrange_einops_to_torch(x, patch_size):
 
 
 def vision_encoder(input_BCHW: torch.Tensor, w: nn.Module, config: VisionConfig):
-    x = rearrange_einops_to_torch(input_BCHW, config.enc_patch_size)
+    x = create_patches(input_BCHW, config.enc_patch_size)
 
     x = linear(x, w.patch_emb)
     x = x + w.pos_emb

--- a/moondream/torch/vision.py
+++ b/moondream/torch/vision.py
@@ -42,13 +42,27 @@ def prepare_crops(
     return all_crops, overlap_crops["tiling"]
 
 
+def rearrange_einops_to_torch(x, patch_size):
+    # Original shape: [B, C, H, W]
+    B, C, H, W = x.shape
+    P1 = P2 = patch_size
+
+    # Step 1: Split H and W dimensions into patches
+    # [B, C, H/P1, P1, W/P2, P2]
+    x = x.reshape(B, C, H // P1, P1, W // P2, P2)
+
+    # Step 2: Rearrange dimensions to match target shape
+    # [B, H/P1, W/P2, C, P1, P2]
+    x = x.permute(0, 2, 4, 1, 3, 5)
+
+    # Step 3: Combine dimensions to get final shape
+    # [B, (H/P1)*(W/P2), C*P1*P2]
+    x = x.reshape(B, (H // P1) * (W // P2), C * P1 * P2)
+
+    return x
+
 def vision_encoder(input_BCHW: torch.Tensor, w: nn.Module, config: VisionConfig):
-    x = rearrange(
-        input_BCHW,
-        "b c (h p1) (w p2) -> b (h w) (c p1 p2)",
-        p1=config.enc_patch_size,
-        p2=config.enc_patch_size,
-    )  # B3HW -> B(HxW)(3xP1xP2), aka BTC
+    x = rearrange_einops_to_torch(input_BCHW, config.enc_patch_size)
 
     x = linear(x, w.patch_emb)
     x = x + w.pos_emb

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pyvips==2.2.3
 torch==2.3.1
 torchvision==0.18.1
 transformers==4.44.0
-einops==0.8.0
 gradio==4.38.1
 
 # Needed for running evals


### PR DESCRIPTION
Replaces the einops "rearrange" operation with native pytorch so that executorch can export this model.