### PR TITLE
Fix TextVQA eval script to be the same as VLMEvalKit's

### DIFF
--- a/moondream/eval/utils.py
+++ b/moondream/eval/utils.py
@@ -5,144 +5,144 @@ from typing import List, Tuple
 class VQAScorer:
     def __init__(self):
         self.contractions = {
-            'aint': "ain't",
-            'arent': "aren't",
-            'cant': "can't",
-            'couldve': "could've",
-            'couldnt': "couldn't",
+            "aint": "ain't",
+            "arent": "aren't",
+            "cant": "can't",
+            "couldve": "could've",
+            "couldnt": "couldn't",
             "couldn'tve": "couldn't've",
             "couldnt've": "couldn't've",
-            'didnt': "didn't",
-            'doesnt': "doesn't",
-            'dont': "don't",
-            'hadnt': "hadn't",
+            "didnt": "didn't",
+            "doesnt": "doesn't",
+            "dont": "don't",
+            "hadnt": "hadn't",
             "hadnt've": "hadn't've",
             "hadn'tve": "hadn't've",
-            'hasnt': "hasn't",
-            'havent': "haven't",
-            'hed': "he'd",
+            "hasnt": "hasn't",
+            "havent": "haven't",
+            "hed": "he'd",
             "hed've": "he'd've",
             "he'dve": "he'd've",
-            'hes': "he's",
-            'howd': "how'd",
-            'howll': "how'll",
-            'hows': "how's",
+            "hes": "he's",
+            "howd": "how'd",
+            "howll": "how'll",
+            "hows": "how's",
             "Id've": "I'd've",
             "I'dve": "I'd've",
-            'Im': "I'm",
-            'Ive': "I've",
-            'isnt': "isn't",
-            'itd': "it'd",
+            "Im": "I'm",
+            "Ive": "I've",
+            "isnt": "isn't",
+            "itd": "it'd",
             "itd've": "it'd've",
             "it'dve": "it'd've",
-            'itll': "it'll",
+            "itll": "it'll",
             "let's": "let's",
-            'maam': "ma'am",
-            'mightnt': "mightn't",
+            "maam": "ma'am",
+            "mightnt": "mightn't",
             "mightnt've": "mightn't've",
             "mightn'tve": "mightn't've",
-            'mightve': "might've",
-            'mustnt': "mustn't",
-            'mustve': "must've",
-            'neednt': "needn't",
-            'notve': "not've",
-            'oclock': "o'clock",
-            'oughtnt': "oughtn't",
+            "mightve": "might've",
+            "mustnt": "mustn't",
+            "mustve": "must've",
+            "neednt": "needn't",
+            "notve": "not've",
+            "oclock": "o'clock",
+            "oughtnt": "oughtn't",
             "ow's'at": "'ow's'at",
             "'ows'at": "'ow's'at",
             "'ow'sat": "'ow's'at",
-            'shant': "shan't",
+            "shant": "shan't",
             "shed've": "she'd've",
             "she'dve": "she'd've",
             "she's": "she's",
-            'shouldve': "should've",
-            'shouldnt': "shouldn't",
+            "shouldve": "should've",
+            "shouldnt": "shouldn't",
             "shouldnt've": "shouldn't've",
             "shouldn'tve": "shouldn't've",
-            "somebody'd": 'somebodyd',
+            "somebody'd": "somebodyd",
             "somebodyd've": "somebody'd've",
             "somebody'dve": "somebody'd've",
-            'somebodyll': "somebody'll",
-            'somebodys': "somebody's",
-            'someoned': "someone'd",
+            "somebodyll": "somebody'll",
+            "somebodys": "somebody's",
+            "someoned": "someone'd",
             "someoned've": "someone'd've",
             "someone'dve": "someone'd've",
-            'someonell': "someone'll",
-            'someones': "someone's",
-            'somethingd': "something'd",
+            "someonell": "someone'll",
+            "someones": "someone's",
+            "somethingd": "something'd",
             "somethingd've": "something'd've",
             "something'dve": "something'd've",
-            'somethingll': "something'll",
-            'thats': "that's",
-            'thered': "there'd",
+            "somethingll": "something'll",
+            "thats": "that's",
+            "thered": "there'd",
             "thered've": "there'd've",
             "there'dve": "there'd've",
-            'therere': "there're",
-            'theres': "there's",
-            'theyd': "they'd",
+            "therere": "there're",
+            "theres": "there's",
+            "theyd": "they'd",
             "theyd've": "they'd've",
             "they'dve": "they'd've",
-            'theyll': "they'll",
-            'theyre': "they're",
-            'theyve': "they've",
-            'twas': "'twas",
-            'wasnt': "wasn't",
+            "theyll": "they'll",
+            "theyre": "they're",
+            "theyve": "they've",
+            "twas": "'twas",
+            "wasnt": "wasn't",
             "wed've": "we'd've",
             "we'dve": "we'd've",
-            'weve': "we've",
-            'werent': "weren't",
-            'whatll': "what'll",
-            'whatre': "what're",
-            'whats': "what's",
-            'whatve': "what've",
-            'whens': "when's",
-            'whered': "where'd",
-            'wheres': "where's",
-            'whereve': "where've",
-            'whod': "who'd",
+            "weve": "we've",
+            "werent": "weren't",
+            "whatll": "what'll",
+            "whatre": "what're",
+            "whats": "what's",
+            "whatve": "what've",
+            "whens": "when's",
+            "whered": "where'd",
+            "wheres": "where's",
+            "whereve": "where've",
+            "whod": "who'd",
             "whod've": "who'd've",
             "who'dve": "who'd've",
-            'wholl': "who'll",
-            'whos': "who's",
-            'whove': "who've",
-            'whyll': "why'll",
-            'whyre': "why're",
-            'whys': "why's",
-            'wont': "won't",
-            'wouldve': "would've",
-            'wouldnt': "wouldn't",
+            "wholl": "who'll",
+            "whos": "who's",
+            "whove": "who've",
+            "whyll": "why'll",
+            "whyre": "why're",
+            "whys": "why's",
+            "wont": "won't",
+            "wouldve": "would've",
+            "wouldnt": "wouldn't",
             "wouldnt've": "wouldn't've",
             "wouldn'tve": "wouldn't've",
-            'yall': "y'all",
+            "yall": "y'all",
             "yall'll": "y'all'll",
             "y'allll": "y'all'll",
             "yall'd've": "y'all'd've",
             "y'alld've": "y'all'd've",
             "y'all'dve": "y'all'd've",
-            'youd': "you'd",
+            "youd": "you'd",
             "youd've": "you'd've",
             "you'dve": "you'd've",
-            'youll': "you'll",
-            'youre': "you're",
-            'youve': "you've",
+            "youll": "you'll",
+            "youre": "you're",
+            "youve": "you've",
         }
 
         self.manualMap = {
-            'none': '0',
-            'zero': '0',
-            'one': '1',
-            'two': '2',
-            'three': '3',
-            'four': '4',
-            'five': '5',
-            'six': '6',
-            'seven': '7',
-            'eight': '8',
-            'nine': '9',
-            'ten': '10',
+            "none": "0",
+            "zero": "0",
+            "one": "1",
+            "two": "2",
+            "three": "3",
+            "four": "4",
+            "five": "5",
+            "six": "6",
+            "seven": "7",
+            "eight": "8",
+            "nine": "9",
+            "ten": "10",
         }
 
-        self.articles = ['a', 'an', 'the']
+        self.articles = ["a", "an", "the"]
 
         self.periodStrip = re.compile("(?!<=\d)(\.)(?!\d)")
         self.commaStrip = re.compile("(\d)(\,)(\d)")
@@ -169,19 +169,20 @@ class VQAScorer:
             "?",
             "!",
         ]
-        self.commaStrip = re.compile('(\d)(,)(\d)')  # noqa: W605
-        self.periodStrip = re.compile('(?!<=\d)(\.)(?!\d)')  # noqa: W605
+        self.commaStrip = re.compile("(\d)(,)(\d)")  # noqa: W605
+        self.periodStrip = re.compile("(?!<=\d)(\.)(?!\d)")  # noqa: W605
 
     def process_punctuation(self, inText: str) -> str:
         outText = inText
-        
+
         for p in self.punct:
-            if (p + ' ' in inText or ' ' + p in inText) or (re.search(
-                    self.commaStrip, inText) is not None):
-                outText = outText.replace(p, '')
+            if (p + " " in inText or " " + p in inText) or (
+                re.search(self.commaStrip, inText) is not None
+            ):
+                outText = outText.replace(p, "")
             else:
-                outText = outText.replace(p, ' ')
-        outText = self.periodStrip.sub('', outText, re.UNICODE)
+                outText = outText.replace(p, " ")
+        outText = self.periodStrip.sub("", outText, re.UNICODE)
         return outText
 
     def process_digit_article(self, inText: str) -> str:
@@ -194,33 +195,34 @@ class VQAScorer:
         for wordId, word in enumerate(outText):
             if word in self.contractions:
                 outText[wordId] = self.contractions[word]
-        outText = ' '.join(outText)
+        outText = " ".join(outText)
         return outText
 
     def process_answer(self, answer):
-        answer = answer.replace('\n', ' ')
-        answer = answer.replace('\t', ' ')
+        answer = answer.replace("\n", " ")
+        answer = answer.replace("\t", " ")
         answer = answer.strip()
         answer = self.process_punctuation(answer)
         answer = self.process_digit_article(answer)
         return answer
 
-    def process_line(self, candidate_answer: str, ground_truth_answers: List[str]) -> float:
+    def process_line(
+        self, candidate_answer: str, ground_truth_answers: List[str]
+    ) -> float:
         gt_answers = [self.process_answer(x) for x in gt_answers]
         prediction = self.process_answer(prediction)
         matches = []
         for current_idx, gtAnsDatum in enumerate(gt_answers):
             otherGTAns = [
-                item for ret_gt_idx, item in enumerate(gt_answers)
+                item
+                for ret_gt_idx, item in enumerate(gt_answers)
                 if ret_gt_idx != current_idx
             ]
-            matchingAns = [
-                item for item in otherGTAns if item == prediction
-            ]
+            matchingAns = [item for item in otherGTAns if item == prediction]
             acc = min(1, float(len(matchingAns)) / 3)
             matches.append(acc)
 
-        return sum(matches)/len(matches)
+        return sum(matches) / len(matches)
 
     def compute_score(
         self, candidate_answer: str, ground_truth_answers: List[str]

--- a/moondream/eval/utils.py
+++ b/moondream/eval/utils.py
@@ -5,144 +5,144 @@ from typing import List, Tuple
 class VQAScorer:
     def __init__(self):
         self.contractions = {
-            "aint": "ain't",
-            "arent": "aren't",
-            "cant": "can't",
-            "couldve": "could've",
-            "couldnt": "couldn't",
+            'aint': "ain't",
+            'arent': "aren't",
+            'cant': "can't",
+            'couldve': "could've",
+            'couldnt': "couldn't",
             "couldn'tve": "couldn't've",
             "couldnt've": "couldn't've",
-            "didnt": "didn't",
-            "doesnt": "doesn't",
-            "dont": "don't",
-            "hadnt": "hadn't",
+            'didnt': "didn't",
+            'doesnt': "doesn't",
+            'dont': "don't",
+            'hadnt': "hadn't",
             "hadnt've": "hadn't've",
             "hadn'tve": "hadn't've",
-            "hasnt": "hasn't",
-            "havent": "haven't",
-            "hed": "he'd",
+            'hasnt': "hasn't",
+            'havent': "haven't",
+            'hed': "he'd",
             "hed've": "he'd've",
             "he'dve": "he'd've",
-            "hes": "he's",
-            "howd": "how'd",
-            "howll": "how'll",
-            "hows": "how's",
+            'hes': "he's",
+            'howd': "how'd",
+            'howll': "how'll",
+            'hows': "how's",
             "Id've": "I'd've",
             "I'dve": "I'd've",
-            "Im": "I'm",
-            "Ive": "I've",
-            "isnt": "isn't",
-            "itd": "it'd",
+            'Im': "I'm",
+            'Ive': "I've",
+            'isnt': "isn't",
+            'itd': "it'd",
             "itd've": "it'd've",
             "it'dve": "it'd've",
-            "itll": "it'll",
+            'itll': "it'll",
             "let's": "let's",
-            "maam": "ma'am",
-            "mightnt": "mightn't",
+            'maam': "ma'am",
+            'mightnt': "mightn't",
             "mightnt've": "mightn't've",
             "mightn'tve": "mightn't've",
-            "mightve": "might've",
-            "mustnt": "mustn't",
-            "mustve": "must've",
-            "neednt": "needn't",
-            "notve": "not've",
-            "oclock": "o'clock",
-            "oughtnt": "oughtn't",
+            'mightve': "might've",
+            'mustnt': "mustn't",
+            'mustve': "must've",
+            'neednt': "needn't",
+            'notve': "not've",
+            'oclock': "o'clock",
+            'oughtnt': "oughtn't",
             "ow's'at": "'ow's'at",
             "'ows'at": "'ow's'at",
             "'ow'sat": "'ow's'at",
-            "shant": "shan't",
+            'shant': "shan't",
             "shed've": "she'd've",
             "she'dve": "she'd've",
             "she's": "she's",
-            "shouldve": "should've",
-            "shouldnt": "shouldn't",
+            'shouldve': "should've",
+            'shouldnt': "shouldn't",
             "shouldnt've": "shouldn't've",
             "shouldn'tve": "shouldn't've",
-            "somebody'd": "somebodyd",
+            "somebody'd": 'somebodyd',
             "somebodyd've": "somebody'd've",
             "somebody'dve": "somebody'd've",
-            "somebodyll": "somebody'll",
-            "somebodys": "somebody's",
-            "someoned": "someone'd",
+            'somebodyll': "somebody'll",
+            'somebodys': "somebody's",
+            'someoned': "someone'd",
             "someoned've": "someone'd've",
             "someone'dve": "someone'd've",
-            "someonell": "someone'll",
-            "someones": "someone's",
-            "somethingd": "something'd",
+            'someonell': "someone'll",
+            'someones': "someone's",
+            'somethingd': "something'd",
             "somethingd've": "something'd've",
             "something'dve": "something'd've",
-            "somethingll": "something'll",
-            "thats": "that's",
-            "thered": "there'd",
+            'somethingll': "something'll",
+            'thats': "that's",
+            'thered': "there'd",
             "thered've": "there'd've",
             "there'dve": "there'd've",
-            "therere": "there're",
-            "theres": "there's",
-            "theyd": "they'd",
+            'therere': "there're",
+            'theres': "there's",
+            'theyd': "they'd",
             "theyd've": "they'd've",
             "they'dve": "they'd've",
-            "theyll": "they'll",
-            "theyre": "they're",
-            "theyve": "they've",
-            "twas": "'twas",
-            "wasnt": "wasn't",
+            'theyll': "they'll",
+            'theyre': "they're",
+            'theyve': "they've",
+            'twas': "'twas",
+            'wasnt': "wasn't",
             "wed've": "we'd've",
             "we'dve": "we'd've",
-            "weve": "we've",
-            "werent": "weren't",
-            "whatll": "what'll",
-            "whatre": "what're",
-            "whats": "what's",
-            "whatve": "what've",
-            "whens": "when's",
-            "whered": "where'd",
-            "wheres": "where's",
-            "whereve": "where've",
-            "whod": "who'd",
+            'weve': "we've",
+            'werent': "weren't",
+            'whatll': "what'll",
+            'whatre': "what're",
+            'whats': "what's",
+            'whatve': "what've",
+            'whens': "when's",
+            'whered': "where'd",
+            'wheres': "where's",
+            'whereve': "where've",
+            'whod': "who'd",
             "whod've": "who'd've",
             "who'dve": "who'd've",
-            "wholl": "who'll",
-            "whos": "who's",
-            "whove": "who've",
-            "whyll": "why'll",
-            "whyre": "why're",
-            "whys": "why's",
-            "wont": "won't",
-            "wouldve": "would've",
-            "wouldnt": "wouldn't",
+            'wholl': "who'll",
+            'whos': "who's",
+            'whove': "who've",
+            'whyll': "why'll",
+            'whyre': "why're",
+            'whys': "why's",
+            'wont': "won't",
+            'wouldve': "would've",
+            'wouldnt': "wouldn't",
             "wouldnt've": "wouldn't've",
             "wouldn'tve": "wouldn't've",
-            "yall": "y'all",
+            'yall': "y'all",
             "yall'll": "y'all'll",
             "y'allll": "y'all'll",
             "yall'd've": "y'all'd've",
             "y'alld've": "y'all'd've",
             "y'all'dve": "y'all'd've",
-            "youd": "you'd",
+            'youd': "you'd",
             "youd've": "you'd've",
             "you'dve": "you'd've",
-            "youll": "you'll",
-            "youre": "you're",
-            "youve": "you've",
+            'youll': "you'll",
+            'youre': "you're",
+            'youve': "you've",
         }
 
         self.manualMap = {
-            "none": "0",
-            "zero": "0",
-            "one": "1",
-            "two": "2",
-            "three": "3",
-            "four": "4",
-            "five": "5",
-            "six": "6",
-            "seven": "7",
-            "eight": "8",
-            "nine": "9",
-            "ten": "10",
+            'none': '0',
+            'zero': '0',
+            'one': '1',
+            'two': '2',
+            'three': '3',
+            'four': '4',
+            'five': '5',
+            'six': '6',
+            'seven': '7',
+            'eight': '8',
+            'nine': '9',
+            'ten': '10',
         }
 
-        self.articles = ["a", "an", "the"]
+        self.articles = ['a', 'an', 'the']
 
         self.periodStrip = re.compile("(?!<=\d)(\.)(?!\d)")
         self.commaStrip = re.compile("(\d)(\,)(\d)")
@@ -169,35 +169,58 @@ class VQAScorer:
             "?",
             "!",
         ]
+        self.commaStrip = re.compile('(\d)(,)(\d)')  # noqa: W605
+        self.periodStrip = re.compile('(?!<=\d)(\.)(?!\d)')  # noqa: W605
 
-    def processPunctuation(self, inText: str) -> str:
-        """Exactly matching the VQAEval processPunctuation method"""
+    def process_punctuation(self, inText: str) -> str:
         outText = inText
+        
         for p in self.punct:
-            if (p + " " in inText or " " + p in inText) or (
-                re.search(self.commaStrip, inText) != None
-            ):
-                outText = outText.replace(p, "")
+            if (p + ' ' in inText or ' ' + p in inText) or (re.search(
+                    self.commaStrip, inText) is not None):
+                outText = outText.replace(p, '')
             else:
-                outText = outText.replace(p, " ")
-        outText = self.periodStrip.sub("", outText, re.UNICODE)
+                outText = outText.replace(p, ' ')
+        outText = self.periodStrip.sub('', outText, re.UNICODE)
         return outText
 
-    def processDigitArticle(self, inText: str) -> str:
-        """Exactly matching the VQAEval processDigitArticle method"""
+    def process_digit_article(self, inText: str) -> str:
         outText = []
         tempText = inText.lower().split()
         for word in tempText:
             word = self.manualMap.setdefault(word, word)
             if word not in self.articles:
                 outText.append(word)
-
         for wordId, word in enumerate(outText):
             if word in self.contractions:
                 outText[wordId] = self.contractions[word]
-
-        outText = " ".join(outText)
+        outText = ' '.join(outText)
         return outText
+
+    def process_answer(self, answer):
+        answer = answer.replace('\n', ' ')
+        answer = answer.replace('\t', ' ')
+        answer = answer.strip()
+        answer = self.process_punctuation(answer)
+        answer = self.process_digit_article(answer)
+        return answer
+
+    def process_line(self, candidate_answer: str, ground_truth_answers: List[str]) -> float:
+        gt_answers = [self.process_answer(x) for x in gt_answers]
+        prediction = self.process_answer(prediction)
+        matches = []
+        for current_idx, gtAnsDatum in enumerate(gt_answers):
+            otherGTAns = [
+                item for ret_gt_idx, item in enumerate(gt_answers)
+                if ret_gt_idx != current_idx
+            ]
+            matchingAns = [
+                item for item in otherGTAns if item == prediction
+            ]
+            acc = min(1, float(len(matchingAns)) / 3)
+            matches.append(acc)
+
+        return sum(matches)/len(matches)
 
     def compute_score(
         self, candidate_answer: str, ground_truth_answers: List[str]
@@ -207,9 +230,7 @@ class VQAScorer:
         exactly matching the VQAEval scoring logic
         """
         # Process candidate answer
-        candidate = candidate_answer.replace("\n", " ")
-        candidate = candidate.replace("\t", " ")
-        candidate = candidate.strip()
+        candidate = self.process_answer(candidate_answer)
 
         # Process ground truth answers
         processed_gts = []
@@ -221,10 +242,10 @@ class VQAScorer:
 
         # If there are multiple different answers, apply additional processing
         if len(set(processed_gts)) > 1:
-            candidate = self.processPunctuation(candidate)
-            candidate = self.processDigitArticle(candidate)
+            candidate = self.process_punctuation(candidate)
+            candidate = self.process_digit_article(candidate)
             processed_gts = [
-                self.processPunctuation(self.processDigitArticle(gt))
+                self.process_punctuation(self.process_digit_article(gt))
                 for gt in processed_gts
             ]
 
@@ -233,21 +254,3 @@ class VQAScorer:
         score = min(1.0, float(len(matching_answers)) / 3.0)
 
         return score
-
-    def find_best_answer(
-        self, candidate_answers: List[str], ground_truth_answers: List[str]
-    ) -> Tuple[str, float]:
-        """
-        Find the candidate answer that gets the highest VQA score.
-        Returns (best_answer, score)
-        """
-        best_score = -1
-        best_answer = None
-
-        for candidate in candidate_answers:
-            score = self.compute_score(candidate, ground_truth_answers)
-            if score > best_score:
-                best_score = score
-                best_answer = candidate
-
-        return best_answer, best_score


### PR DESCRIPTION
Fix TextVQA eval script to be the same as VLMEvalKit's.

Need to submit PR to VLMEvalKit with new moondream .query() function and prompts.