### PR TITLE
relaxed correctness chartqa

### DIFF
--- a/moondream/eval/chartqa.py
+++ b/moondream/eval/chartqa.py
@@ -11,6 +11,50 @@ from ..torch.weights import load_weights_into_model
 PREFIX = "Analyze the chart carefully, consider both visual features and data values, and provide a precise answer without any additional explanation or formatting. "
 
 
+# https://github.com/google-research/pix2struct/blob/main/pix2struct/metrics.py#L81
+def relaxed_correctness(
+    target: str, prediction: str, max_relative_change: float = 0.05
+) -> bool:
+    """Calculates relaxed correctness.
+
+    The correctness tolerates certain error ratio defined by max_relative_change.
+    See https://arxiv.org/pdf/2203.10244.pdf, end of section 5.1:
+    “Following Methani et al. (2020), we use a relaxed accuracy measure for the
+    numeric answers to allow a minor inaccuracy that may result from the automatic
+    data extraction process. We consider an answer to be correct if it is within
+    5% of the gold answer. For non-numeric answers, we still need an exact match
+    to consider an answer to be correct.”
+
+    Args:
+      target: Target string.
+      prediction: Predicted string.
+      max_relative_change: Maximum relative change.
+
+    Returns:
+      Whether the prediction was correct given the specified tolerance.
+    """
+
+    def _to_float(text):
+        try:
+            if text.endswith("%"):
+                # Convert percentages to floats.
+                return float(text.rstrip("%")) / 100.0
+            else:
+                return float(text)
+        except ValueError:
+            return None
+
+    prediction = str(prediction)
+    target = str(target)
+    prediction_float = _to_float(prediction)
+    target_float = _to_float(target)
+    if prediction_float is not None and target_float:
+        relative_change = abs(prediction_float - target_float) / abs(target_float)
+        return relative_change <= max_relative_change
+    else:
+        return prediction == target
+
+
 def eval_chartqa(model, debug=False):
     dataset = datasets.load_dataset("vikhyatk/chartqa", split="test")
 
@@ -28,10 +72,32 @@ def eval_chartqa(model, debug=False):
             answer = qa["answer"]
             model_answer = model.query(encoded_image, question)["answer"]
 
+            # Attempt to parse both answers into lists, otherwise
+            try:
+                answer_list = eval(answer)
+                model_answer_list = eval(model_answer)
+                if not (
+                    isinstance(answer_list, list)
+                    and isinstance(model_answer_list, list)
+                    and len(answer_list) == len(model_answer_list)
+                ):
+                    raise ValueError
+            except:
+                # If parsing fails or lengths are not equal, compare the strings directly instead
+                answer_list = [answer]
+                model_answer_list = [model_answer]
+
             total += 1
             if qa["source"] == "human":
                 human_total += 1
-            if model_answer.strip().lower() == answer.strip().lower():
+
+            if all(
+                relaxed_correctness(
+                    str(cur_answer).strip().lower(),
+                    str(cur_model_answer).strip().lower(),
+                )
+                for cur_answer, cur_model_answer in zip(answer_list, model_answer_list)
+            ):
                 correct += 1
                 if qa["source"] == "human":
                     human_correct += 1

--- a/moondream/eval/chartqa.py
+++ b/moondream/eval/chartqa.py
@@ -3,6 +3,7 @@ import datasets
 import torch
 
 from tqdm import tqdm
+import json
 
 from ..torch.config import MoondreamConfig
 from ..torch.moondream import MoondreamModel
@@ -74,8 +75,8 @@ def eval_chartqa(model, debug=False):
 
             # Attempt to parse both answers into lists, otherwise
             try:
-                answer_list = eval(answer)
-                model_answer_list = eval(model_answer)
+                answer_list = json.loads(answer)
+                model_answer_list = json.loads(model_answer)
                 if not (
                     isinstance(answer_list, list)
                     and isinstance(model_answer_list, list)


### PR DESCRIPTION
Match VLMEvalKit's implementation of relaxed correctness for ChartQA:

```The correctness tolerates certain error ratio defined by max_relative_change.
    See https://arxiv.org/pdf/2203.10244.pdf, end of section 5.1:
    “Following Methani et al. (2020), we use a relaxed accuracy measure for the
    numeric answers to allow a minor inaccuracy that may result from the automatic
    data extraction process. We consider an answer to be correct if it is within
    5% of the gold answer. For non-numeric answers, we still need an exact match
    to consider an answer to be correct.”
```