### PR TITLE
[Docs] Add note in ReadMe about huggingface revisions that support attn_implementation="flash_attention_2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ model = AutoModelForCausalLM.from_pretrained(
     torch_dtype=torch.float16, attn_implementation="flash_attention_2"
 ).to("cuda")
 ```
+> **_NOTE:_**  Flash Attention supports the following revisions: `2024-08-26`, `2024-07-23`, `2024-05-20`, `2024-05-08`, `2024-04-02`, `2024-03-13`, `2024-03-06`.


### PR DESCRIPTION
Found that the latest revision `2025-01-09` doesn't support specifying `attn_implementation="flash_attention_2"` in the ` AutoModelForCausalLM.from_pretrained(...)` initialization. Added a note to the docs for the same.

Took me a little time to figure out why it wasn't working. So I thought a note would be helpful. Feel free to edit/close the PR if not needed.