### PR TITLE
make max_points configurable

### DIFF
--- a/clients/python/moondream/onnx_vl.py
+++ b/clients/python/moondream/onnx_vl.py
@@ -374,6 +374,7 @@ class OnnxVL(VLM):
         self,
         image: Union[Image.Image, EncodedImage],
         object: str,
+        max_points: int = 50
     ) -> PointOutput:
         if not (
             hasattr(self, "coord_decoder")
@@ -395,7 +396,7 @@ class OnnxVL(VLM):
 
         points = []
         pos = encoded_image.pos
-        max_points = 50
+        
 
         while len(points) < max_points:
             logits, hidden = run_decoder(self.text_decoder, hidden, kv_cache, pos)


### PR DESCRIPTION
Hi @vikhyat ,

with this PR, the maximum number of detectable points becomes an optional parameter. This might be useful for scientists like me who seek to discover the limits of spot detection using VLMs.

moondream is fantastic for this btw! Thanks so much for publishing this!

Best,
Robert
