### PR TITLE
return 404 when endpoint is not found

### DIFF
--- a/clients/python/moondream/server.py
+++ b/clients/python/moondream/server.py
@@ -151,6 +151,8 @@ class MoondreamHandler(server.BaseHTTPRequestHandler):
                 except Exception as e:
                     logger.error("Object pointing error", exc_info=True)
                     self.send_error_response("Object pointing failed.")
+            else:
+                self.send_error_response("Endpoint not found", status=404)
 
         except Exception as e:
             logger.error("Unexpected error in request handling", exc_info=True)


### PR DESCRIPTION
This would have saved me some time when running locally and not understanding why my curls were failing with

```
* Empty reply from server
* Closing connection
```