### PR TITLE
v. 0.0.5 from the example seems to need onnxruntime==1.19.2 etc. (but…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ print("Answer:", answer)
 ```
 
 ⚠️ Note: The Python client currently only supports CPU inference. CUDA (GPU) and MPS (Apple Silicon) optimization is coming soon. For GPU support, use the Hugging Face transformers implementation below.
+Note: If you want to use version 0.0.5 as in this example: pip install onnxruntime==1.19.2 ... because an automatic install may download a more recent version, such as 1.21.1, which seems to be incompatible; onnx==1.17.0
 
 For complete documentation of the Python client, including cloud API usage and additional features, see the [Python Client README](clients/python/README.md).
 


### PR DESCRIPTION
… not more recent such as an automatically installed current 1.21.1 seems incompatible)

While testing the example, I discovered this incompatibility which v. 0.0.5 and the more recent versions of onnxruntime if installing with pip install moondream==0.0.5 such as:

Successfully installed onnx-1.17.0 onnxruntime-1.21.1 (a too recent version):

Z:\>python -c "import moondream as md; print(md.__version__) Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\...\.conda\envs\clip\lib\site-packages\moondream\__init__.py", line 3, in <module>
    from .onnx_vl import OnnxVL
  File "C:\Users\...\.conda\envs\clip\lib\site-packages\moondream\onnx_vl.py", line 5, in <module>
    import onnxruntime as ort
  File "C:\Users\...\.conda\envs\clip\lib\site-packages\onnxruntime\__init__.py", line 61, in <module>
    raise import_capi_exception
  File "C:\Users\...\.conda\envs\clip\lib\site-packages\onnxruntime\__init__.py", line 24, in <module>
    from onnxruntime.capi._pybind_state import (
  File "C:\Users\...\.conda\envs\clip\lib\site-packages\onnxruntime\capi\_pybind_state.py", line 32, in <module>
    from .onnxruntime_pybind11_state import *  # noqa
ImportError: DLL load failed while importing onnxruntime_pybind11_state: A dynamic link library (DLL) initialization routine failed.

I downgraded to 1.19.2 and it worked.

Note: If you want to use version 0.0.5 as in this example: pip install onnxruntime==1.19.2 ... because an automatic install may download a more recent version, such as 1.21.1, which seems to be incompatible; onnx==1.17.0