### PR TITLE
fix python client server inference with no api key

### DIFF
--- a/clients/python/moondream/__init__.py
+++ b/clients/python/moondream/__init__.py
@@ -38,5 +38,8 @@ def vl(
             raise ValueError("An api_key is required for cloud inference.")
 
         return CloudVL(api_url=api_url)
+    
+    if api_url:
+        return CloudVL(api_url=api_url) 
 
     raise ValueError("At least one of `model`, `api_key`, or `api_url` is required.")


### PR DESCRIPTION
When using the Python client with a custom api_url (i.e. localhost) it raises an error if there's no api key (which isn't needed for local server)