### PR TITLE
PIL Fallback

### DIFF
--- a/moondream/torch/image_crops.py
+++ b/moondream/torch/image_crops.py
@@ -1,9 +1,19 @@
 import math
 import numpy as np
 import torch
-import pyvips
 
 from typing import TypedDict
+
+try:
+    import pyvips
+
+    HAS_VIPS = True
+    print("using vips")
+except:
+    from PIL import Image
+
+    HAS_VIPS = False
+    print("using fallback")
 
 
 def select_tiling(
@@ -113,18 +123,30 @@ def overlap_crop_image(
         tiling[1] * crop_window_size + total_margin_pixels,
     )
 
-    # Convert to vips for resizing
-    vips_image = pyvips.Image.new_from_array(image)
-    scale_x = target_size[1] / image.shape[1]
-    scale_y = target_size[0] / image.shape[0]
-    resized = vips_image.resize(scale_x, vscale=scale_y)
-    image = resized.numpy()
+    if HAS_VIPS:
+        # Convert to vips for resizing
+        vips_image = pyvips.Image.new_from_array(image)
+        scale_x = target_size[1] / image.shape[1]
+        scale_y = target_size[0] / image.shape[0]
+        resized = vips_image.resize(scale_x, vscale=scale_y)
+        image = resized.numpy()
 
-    # Create global crop
-    scale_x = base_size[1] / vips_image.width
-    scale_y = base_size[0] / vips_image.height
-    global_vips = vips_image.resize(scale_x, vscale=scale_y)
-    crops[0] = global_vips.numpy()
+        # Create global crop
+        scale_x = base_size[1] / vips_image.width
+        scale_y = base_size[0] / vips_image.height
+        global_vips = vips_image.resize(scale_x, vscale=scale_y)
+        crops[0] = global_vips.numpy()
+    else:
+        pil_img = Image.fromarray(image)
+        resized = pil_img.resize(
+            (int(target_size[1]), int(target_size[0])),
+            resample=Image.Resampling.LANCZOS,
+        )
+        image = np.asarray(resized)
+        global_pil = pil_img.resize(
+            (int(base_size[1]), int(base_size[0])), resample=Image.Resampling.LANCZOS
+        )
+        crops[0] = np.asarray(global_pil)
 
     for i in range(tiling[0]):
         for j in range(tiling[1]):

--- a/moondream/torch/image_crops.py
+++ b/moondream/torch/image_crops.py
@@ -8,12 +8,10 @@ try:
     import pyvips
 
     HAS_VIPS = True
-    print("using vips")
 except:
     from PIL import Image
 
     HAS_VIPS = False
-    print("using fallback")
 
 
 def select_tiling(

--- a/moondream/torch/image_crops.py
+++ b/moondream/torch/image_crops.py
@@ -135,12 +135,15 @@ def overlap_crop_image(
         global_vips = vips_image.resize(scale_x, vscale=scale_y)
         crops[0] = global_vips.numpy()
     else:
+        # Fallback to PIL
         pil_img = Image.fromarray(image)
         resized = pil_img.resize(
             (int(target_size[1]), int(target_size[0])),
             resample=Image.Resampling.LANCZOS,
         )
         image = np.asarray(resized)
+
+        # Create global crop
         global_pil = pil_img.resize(
             (int(base_size[1]), int(base_size[0])), resample=Image.Resampling.LANCZOS
         )

--- a/moondream/torch/moondream.py
+++ b/moondream/torch/moondream.py
@@ -172,8 +172,7 @@ class MoondreamModel(nn.Module):
     def _run_vision_encoder(self, image: Image.Image) -> torch.Tensor:
         all_crops, tiling = prepare_crops(image, self.config.vision, device=self.device)
 
-        if self.device.type != "mps":
-            torch._dynamo.mark_dynamic(all_crops, 0)
+        torch._dynamo.mark_dynamic(all_crops, 0)
 
         outputs = self._vis_enc(all_crops)
 
@@ -239,8 +238,7 @@ class MoondreamModel(nn.Module):
     ):
         with torch.inference_mode():
             prompt_emb = text_encoder(prompt_tokens, self.text)
-            if self.device.type != "mps":
-                torch._dynamo.mark_dynamic(prompt_emb, 1)
+            torch._dynamo.mark_dynamic(prompt_emb, 1)
 
             mask = self.attn_mask[:, :, pos : pos + prompt_emb.size(1), :]
             pos_ids = torch.arange(pos, pos + prompt_emb.size(1), dtype=torch.long)

--- a/moondream/torch/sample.py
+++ b/moondream/torch/sample.py
@@ -21,9 +21,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if torch.cuda.is_available():
-        torch.set_default_device("cuda")
+        device = "cuda"
     elif torch.backends.mps.is_available():
-        torch.set_default_device("mps")
+        device = "mps"
 
     # Load model.
     if args.config is not None:
@@ -34,6 +34,7 @@ if __name__ == "__main__":
         config = MoondreamConfig()
     model = MoondreamModel(config)
     load_weights_into_model(args.model, model)
+    model = model.to("mps")
 
     # Encode image.
     image_path = args.image

--- a/moondream/torch/sample.py
+++ b/moondream/torch/sample.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         config = MoondreamConfig()
     model = MoondreamModel(config)
     load_weights_into_model(args.model, model)
-    model = model.to("mps")
+    model = model.to(device)
 
     # Encode image.
     image_path = args.image

--- a/moondream/torch/sample.py
+++ b/moondream/torch/sample.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
 
         # Detect gaze
         model.detect_gaze(encoded_image, (0.5, 0.5))
-    else:
+    elif model.device.type != "mps":
         torch._dynamo.reset()
         model.compile()
 
@@ -142,3 +142,5 @@ if __name__ == "__main__":
         print(f"  Mean: {sum(query_speeds)/len(query_speeds):.2f}")
         print(f"  Min:  {min(query_speeds):.2f}")
         print(f"  Max:  {max(query_speeds):.2f}")
+    else:
+        raise ValueError("To run benchmarks, make sure you are on a CUDA device")


### PR DESCRIPTION
Some users have had trouble with Pyvips. Added a fallback to use PIL inside of image_crops.py.
When using PIL, there is a slight wall clock penalty of about 0.2 second (tested on m3 MBA).

Added a check before "torch._dynamo.mark_dynamic" which prevents it from running on Mac.

These changes have been tested on Mac and Ubuntu.