### PR TITLE
Add MOONDREAM_API_KEY environment variable support 

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -42,14 +42,21 @@ pip install moondream[gpu]
 
 To use Moondream's cloud API, you'll first need an API key. Sign up for a free
 account at [console.moondream.ai](https://console.moondream.ai) to get your key.
-Once you have your key, you can use it to initialize the client as shown below.
+
+**Recommended:** Set your API key as an environment variable for security and convenience. Set it in your shell or use a secret manager:
+
+```bash
+export MOONDREAM_API_KEY=your-api-key
+```
+
+The client will automatically use this variable if you do not pass `api_key` directly.
 
 ```python
 import moondream as md
 from PIL import Image
 
-# Initialize with API key
-model = md.vl(api_key="your-api-key")
+# Initialize (api_key will be read from MOONDREAM_API_KEY if not provided)
+model = md.vl()
 
 # Load an image
 image = Image.open("path/to/image.jpg")
@@ -66,6 +73,10 @@ print("Answer:", answer)
 for chunk in model.caption(image, stream=True)["caption"]:
     print(chunk, end="", flush=True)
 ```
+
+#### Security Considerations
+- **Never commit your real API key to version control.**
+- Use environment variables or secret managers to keep your API key secure.
 
 ### Using Local Inference
 

--- a/clients/python/moondream/__init__.py
+++ b/clients/python/moondream/__init__.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import os
 
 from .cloud_vl import CloudVL
 from .types import VLM
@@ -12,6 +13,9 @@ def vl(
     api_key: Optional[str] = None,
     api_url: Optional[str] = None,
 ) -> VLM:
+    if api_key is None:
+        api_key = os.getenv("MOONDREAM_API_KEY")
+
     if model:
         model_filetype = model.split(".")[-1]
         if model_filetype == "safetensors":


### PR DESCRIPTION
Closes #228

Enhance the README with instructions for setting the API key as an environment variable and update client initialization to read the API key securely. Include security considerations to prevent committing sensitive information to version control.