### PR TITLE
Lora

### DIFF
--- a/moondream/torch/f_lora.py
+++ b/moondream/torch/f_lora.py
@@ -1,0 +1,144 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import shutil
+
+
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+
+from .utils import hf_hub_dir, rename_state_dict
+
+
+LORA_ENDPOINT = "https://api-staging.moondream.ai/v1/variants/{lora_id}/download"
+LORA_KEYWORDS = ["mlp", "attn"]
+SCALE = 8 / 16
+
+
+def replace_with_lora_linear(model: nn.Module, keywords=LORA_KEYWORDS):
+    # TODO: change to just loop through named params
+    named_mods = {name: mod for name, mod in model.named_modules()}
+    for name, mod in named_mods.items():
+        if isinstance(mod, nn.Linear) and (
+            not keywords or any(k in name for k in keywords)
+        ):
+
+            new_layer = LoRALinear(
+                mod.in_features,
+                mod.out_features,
+                bias=mod.bias is not None,
+                dtype=mod.weight.dtype,
+                device=mod.weight.device,
+            )
+            new_layer.weight = mod.weight
+            new_layer.bias = mod.bias
+
+            parent = model
+            *path, leaf = name.split(".")
+            for attr in path:
+                parent = getattr(parent, attr)
+            setattr(parent, leaf, new_layer)
+
+
+class LoRALinear(nn.Linear):
+
+    def __init__(self, in_features, out_features, bias=True, **kw):
+        super().__init__(in_features, out_features, bias=bias, **kw)
+
+        self.register_buffer(
+            "lora_delta",
+            torch.zeros_like(self.weight, dtype=self.weight.dtype),
+            persistent=False,
+        )
+
+        self.register_buffer(
+            "_lora_active", torch.tensor(0, dtype=torch.bool), persistent=False
+        )
+
+    def set_lora(self, delta: torch.Tensor | None):
+        if delta is None:
+            self._lora_active.zero_()
+        else:
+            if delta.shape != self.weight.shape:
+                raise ValueError("LoRA delta shape mismatch")
+            self.lora_delta = delta
+            self._lora_active.fill_(True)
+
+    def forward(self, x):
+        if self._lora_active:
+            return F.linear(
+                x,
+                self.weight + self.lora_delta.to(self.weight.device),
+                self.bias.to(self.weight.device),
+            )
+        return F.linear(x, self.weight, self.bias)
+
+
+class LoRAPool:
+
+    def __init__(self, model: nn.Module, device):
+        self.model = model
+        self.device = device
+        self._cpu, self._gpu = {}, {}
+
+        self._layers = {
+            name: mod
+            for name, mod in model.named_modules()
+            if isinstance(mod, LoRALinear)
+        }
+
+    def activate(self, lora_id: str | None):
+        for m in self._layers.values():
+            m.set_lora(None)
+
+        if lora_id is None:
+            return
+
+        delta_map = self._get_gpu(lora_id)
+        for name, delta in delta_map.items():
+            self._layers[name].set_lora(delta)
+
+    def _get_gpu(self, lora_id):
+        if lora_id in self._gpu:
+            return self._gpu[lora_id]
+
+        if lora_id not in self._cpu:
+            self._cpu[lora_id] = self._load_delta_cpu(lora_id)
+
+        self._gpu[lora_id] = {
+            n: t.to(self.device, non_blocking=True)
+            for n, t in self._cpu[lora_id].items()
+        }
+        return self._gpu[lora_id]
+
+    def _load_delta_cpu(self, lora_id):
+        sd = rename_state_dict(
+            torch.load(self._retrieve_lora(lora_id), map_location="cpu")
+        )
+        scale = sd.get("scale", SCALE)
+        out = {}
+        for prefix in {k.rsplit(".", 1)[0] for k in sd.keys()}:
+            A = sd[f"{prefix}.A"]
+            B = sd[f"{prefix}.B"]
+            out[prefix] = (B @ A) * scale
+        return out
+
+    def _retrieve_lora(self, lora_id) -> Path:
+        cache_dir = hf_hub_dir() / "moondream_lora" / lora_id
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        dest = cache_dir / "lora.pt"
+        if dest.exists():
+            return dest
+
+        url = LORA_ENDPOINT.format(lora_id=lora_id)
+        req = Request(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; LoraDownloader/1.0)",
+            },
+        )
+        with urlopen(req) as r, open(dest, "wb") as f:
+            shutil.copyfileobj(r, f)
+
+        return dest

--- a/moondream/torch/flora.py
+++ b/moondream/torch/flora.py
@@ -1,0 +1,37 @@
+import contextlib
+import torch
+import torch.nn as nn
+
+from .utils import hf_hub_dir, rename_state_dict
+
+R = 16
+ALPHA = 8
+SCALE = ALPHA / R
+LORA_KEYWORDS = ["mlp", "attn"]
+LORA_ENDPOINT = "https://api-staging.moondream.ai/v1/variants/{lora_id}/download"
+
+
+def load_lora_state_dict(lora_id: str) -> dict[str, torch.Tensor]:
+    dest = download_lora()
+
+
+def download_lora(lora_id: str):
+    """Download LoRA file to HF_HUB_CACHE/moondream_lora"""
+
+    cache_dir = hf_hub_dir() / "moondream_lora" / lora_id
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    dest = cache_dir / "lora.pt"
+    if dest.exists():
+        return dest
+
+    url = LORA_ENDPOINT.format(lora_id=lora_id)
+    req = Request(
+        url,
+        headers={
+            "User-Agent": "Mozilla/5.0 (compatible; LoraDownloader/1.0)",
+        },
+    )
+    with urlopen(req) as r, open(dest, "wb") as f:
+        shutil.copyfileobj(r, f)
+
+    return dest

--- a/moondream/torch/hf_moondream.py
+++ b/moondream/torch/hf_moondream.py
@@ -135,7 +135,7 @@ class HfMoondream(PreTrainedModel):
             )
 
             def generator():
-                for token in self.model._generate_answer(
+                for token in self.model._generate_text(
                     prompt_tokens,
                     image_embeds.kv_cache,
                     image_embeds.pos,

--- a/moondream/torch/lora.py
+++ b/moondream/torch/lora.py
@@ -57,15 +57,14 @@ def setup_lora(model, lora_id: str):
     """Downloads lora, adds parametrization, and then loads the lora weights."""
 
     lora_dest = download_lora(lora_id)
-    add_lora(model.text, keywords=LORA_KEYWORDS, r=R, alpha = ALPHA)
-
+    add_lora(model.text, keywords=LORA_KEYWORDS, r=R, alpha=ALPHA)
     sd = torch.load(lora_dest, map_location="cpu")
     model.load_state_dict(rename_state_dict(sd), strict=False, assign=True)
 
 
 def download_lora(lora_id: str):
     """Download LoRA file to HF_HUB_CACHE/moondream_lora"""
-    
+
     cache_dir = hf_hub_dir() / "moondream_lora" / lora_id
     cache_dir.mkdir(parents=True, exist_ok=True)
     dest = cache_dir / "lora.pt"

--- a/moondream/torch/lora.py
+++ b/moondream/torch/lora.py
@@ -1,0 +1,85 @@
+import math
+import torch
+import torch.nn as nn
+import shutil
+
+from torch.nn.utils import parametrize
+from urllib.request import Request, urlopen
+
+from .utils import hf_hub_dir, rename_state_dict
+
+LORA_ENDPOINT = "https://api-staging.moondream.ai/v1/variants/{lora_id}/download"
+R = 16
+ALPHA = 8
+LORA_KEYWORDS = ["mlp", "attn"]
+
+
+class LoRA(nn.Module):
+    """
+    Calculates and returns the adapted weight; intended to be used as a parametrization.
+    Let: W = W + (α / r) * (B @ A)
+    """
+
+    def __init__(self, weight: torch.Tensor, r: int, alpha: int, p: float):
+        super().__init__()
+        out_dim, in_dim = weight.shape
+        self.scale = alpha / r
+        self.A = nn.Parameter(torch.empty(r, in_dim, dtype=weight.dtype))
+        self.B = nn.Parameter(torch.empty(out_dim, r, dtype=weight.dtype))
+
+        nn.init.kaiming_uniform_(self.A, a=math.sqrt(5))
+        nn.init.zeros_(self.B)
+
+    def forward(self, W: torch.Tensor) -> torch.Tensor:
+        return W + self.scale * (self.B @ self.A)
+
+
+def add_lora(
+    model: nn.Module,
+    keywords: list[str] = None,
+    r: int = 16,
+    alpha: int = 32,
+    dropout: float = 0.0,
+):
+    """Attach LoRA to every nn.Linear.weight whose name contains a keyword"""
+
+    for name, mod in model.named_modules():
+        if isinstance(mod, nn.Linear) and (
+            not keywords or any(k in name for k in keywords)
+        ):
+            if not parametrize.is_parametrized(mod, "weight"):
+                parametrize.register_parametrization(
+                    mod, "weight", LoRA(mod.weight, r, alpha, dropout)
+                )
+
+
+def setup_lora(model, lora_id: str):
+    """Downloads lora, adds parametrization, and then loads the lora weights."""
+
+    lora_dest = download_lora(lora_id)
+    add_lora(model.text, keywords=LORA_KEYWORDS, r=R, alpha = ALPHA)
+
+    sd = torch.load(lora_dest, map_location="cpu")
+    model.load_state_dict(rename_state_dict(sd), strict=False, assign=True)
+
+
+def download_lora(lora_id: str):
+    """Download LoRA file to HF_HUB_CACHE/moondream_lora"""
+    
+    cache_dir = hf_hub_dir() / "moondream_lora" / lora_id
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    dest = cache_dir / "lora.pt"
+    if dest.exists():
+        return dest
+
+    url = LORA_ENDPOINT.format(lora_id=lora_id)
+    req = Request(
+        url,
+        headers={
+            "User-Agent": "Mozilla/5.0 (compatible; LoraDownloader/1.0)",
+        },
+    )
+    with urlopen(req) as r, open(dest, "wb") as f:
+        shutil.copyfileobj(r, f)
+
+    return dest

--- a/moondream/torch/utils.py
+++ b/moondream/torch/utils.py
@@ -45,7 +45,6 @@ def remove_outlier_points(points_tuples, k_nearest=2, threshold=2.0):
 
 def hf_hub_dir() -> Path:
     """Return the HuggingFace hub cache directory."""
-
     directory = os.getenv("HF_HUB_CACHE")
     if not directory:
         directory = (
@@ -56,12 +55,12 @@ def hf_hub_dir() -> Path:
 
 def rename_state_dict(state_dict: dict) -> dict:
     """Rename raw weights name for HF."""
-
     rename_rules = [
-        ("text_model.transformer.h", "text.blocks"),
+        ("text_model.transformer.h", "blocks"),
         (".mixer", ".attn"),
         (".out_proj", ".proj"),
         (".Wqkv", ".qkv"),
+        (".parametrizations.weight.0", ""),
     ]
 
     new_state_dict = {}

--- a/moondream/torch/utils.py
+++ b/moondream/torch/utils.py
@@ -2,6 +2,7 @@ import numpy as np
 from pathlib import Path
 import os
 
+
 def remove_outlier_points(points_tuples, k_nearest=2, threshold=2.0):
     """
     Robust outlier detection for list of (x,y) tuples.
@@ -47,13 +48,15 @@ def hf_hub_dir() -> Path:
 
     directory = os.getenv("HF_HUB_CACHE")
     if not directory:
-        directory = Path(os.getenv("HF_HOME", Path.home() / ".cache" / "huggingface")) / "hub"
+        directory = (
+            Path(os.getenv("HF_HOME", Path.home() / ".cache" / "huggingface")) / "hub"
+        )
     return directory
 
 
 def rename_state_dict(state_dict: dict) -> dict:
     """Rename raw weights name for HF."""
-    
+
     rename_rules = [
         ("text_model.transformer.h", "text.blocks"),
         (".mixer", ".attn"),


### PR DESCRIPTION
**Do not merge yet, need to clean and flush out caching logic!**

Added LoRA support to hf_moondream. 

To use a LoRA, pass the `variant_id`. It then downloads the LoRA to the `<hf cache>/moondream_lora/<lora_id>/lora.pt`.

A given LoRA's delta is stored in a buffer. If variant_id is passed to a capability, LoRA becomes active and then the linear layer reads from the buffer.

The LoRA pool contains both cpu and gpu caches. I need to fill out the logic to manage how we decide what lives where. I precompute the delta so we just `self.weight + self.lora_delta `at inference time.

Usage becomes:
```
from transformers import AutoModelForCausalLM
from PIL import Image

model = AutoModelForCausalLM.from_pretrained(
    "moondream/moondream2-lora", trust_remote_code=True
)

model = model.to("cuda")

img = Image.open("/home/ubuntu/image (17).jpg")
print("Short query:")
print(
    model.query(img, "What country is this?", variant_id="geoguesser_lora_only")[
        "answer"
    ]
)
```