### PR TITLE
Set spatial_refs to none after generate_reasoning

### DIFF
--- a/moondream/torch/moondream.py
+++ b/moondream/torch/moondream.py
@@ -671,6 +671,7 @@ class MoondreamModel(nn.Module):
             reasoning_dict = {
                 "reasoning": {"text": reasoning_text, "grounding": reasoning_grounding}
             }
+            spatial_refs = None
         else:
             prompt_tokens[0] += self.config.tokenizer.templates["query"]["suffix"]
             reasoning_dict = {}


### PR DESCRIPTION
In reasoning mode `spatial_refs` did not work. We were passing the `spatial_refs` to generate_answer even when the prompt was suffix only as we has already consumed the prompt with the spatial tokens during `generate_reasoning`. Solution is to set the `spatial_refs` to none after consuming them.