### PR TITLE
feat: add use_flex_decoding parameter for non-CUDA devices

### DIFF
--- a/moondream/torch/hf_moondream.py
+++ b/moondream/torch/hf_moondream.py
@@ -29,9 +29,10 @@ class HfConfig(PretrainedConfig):
     _auto_class = "AutoConfig"
     model_type = "moondream3"
 
-    def __init__(self, **kwargs):
+    def __init__(self, use_flex_decoding=True, **kwargs):
         super().__init__(**kwargs)
         self.config = {"skills": ["query", "caption", "detect", "point"]}
+        self.use_flex_decoding = use_flex_decoding
 
 
 class HfMoondream(PreTrainedModel):
@@ -40,8 +41,9 @@ class HfMoondream(PreTrainedModel):
 
     def __init__(self, config):
         super().__init__(config)
+        use_flex_decoding = getattr(config, 'use_flex_decoding', True)
         self.model = MoondreamModel(
-            MoondreamConfig.from_dict(config.config), setup_caches=False
+            MoondreamConfig.from_dict(config.config), setup_caches=False, use_flex_decoding=use_flex_decoding
         )
         self._is_kv_cache_setup = False
 

--- a/moondream/torch/moondream.py
+++ b/moondream/torch/moondream.py
@@ -93,7 +93,7 @@ def get_mask_mod(mask_mod, offset):
 class MoondreamModel(nn.Module):
 
     def __init__(
-        self, config: MoondreamConfig, dtype=torch.bfloat16, setup_caches=True
+        self, config: MoondreamConfig, dtype=torch.bfloat16, setup_caches=True, use_flex_decoding=True
     ):
         super().__init__()
         self.config = config
@@ -139,7 +139,7 @@ class MoondreamModel(nn.Module):
         attn_mask[..., :prefix_attn_len, :prefix_attn_len] = 1
         self.register_buffer("attn_mask", attn_mask, persistent=False)
 
-        self.use_flex_decoding = True
+        self.use_flex_decoding = use_flex_decoding
         self._causal_block_mask = None
         self._point_gen_indices = None
 


### PR DESCRIPTION
## Summary
Add a `use_flex_decoding` constructor parameter to `MoondreamModel` and `HfConfig` to allow users to disable flex decoding on non-CUDA devices (e.g., MPS on Mac).

## Problem
Moondream 3 uses flex decoding which requires CUDA. Users on Mac with MPS cannot run the model because `create_block_mask` is CUDA-only. Currently, users have to manually patch the source code to set `use_flex_decoding = False`.

## Solution
Add a `use_flex_decoding` parameter that defaults to `True` (backward compatible) but can be set to `False` for non-CUDA devices.

## Changes
- `moondream/torch/moondream.py`: Add `use_flex_decoding` parameter to `MoondreamModel.__init__`
- `moondream/torch/hf_moondream.py`: Add `use_flex_decoding` to `HfConfig` and pass through to `MoondreamModel`

## Usage
```python
# For HuggingFace loading on Mac with MPS
from transformers import AutoModelForCausalLM, AutoConfig

config = AutoConfig.from_pretrained('moondream/moondream3', use_flex_decoding=False)
model = AutoModelForCausalLM.from_pretrained('moondream/moondream3', config=config)
model.to('mps')
```

## Test plan
- [ ] Load model with `use_flex_decoding=True` on CUDA (default behavior unchanged)
- [ ] Load model with `use_flex_decoding=False` on MPS (Mac)
- [ ] Verify inference works correctly with flex decoding disabled

Fixes #316