### PR TITLE
Support multi-GPU eval in tallyqa.py (#69)

### DIFF
--- a/moondream/eval/tallyqa.py
+++ b/moondream/eval/tallyqa.py
@@ -1,6 +1,9 @@
 import argparse
+import os
+
 import datasets
 import torch
+import torch.distributed as dist
 
 from tqdm import tqdm
 
@@ -11,19 +14,29 @@ from ..torch.weights import load_weights_into_model
 PREFIX = "Look at the image carefully and count the objects. Answer with just a number, without any additional text. "
 
 
+def _dist_info():
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_world_size(), dist.get_rank()
+    return 1, 0
+
+
 def eval_tallyqa(model, debug=False):
+    world_size, rank = _dist_info()
+
     dataset = datasets.load_dataset(
         "vikhyatk/tallyqa-test",
         split="test",
         download_config=datasets.DownloadConfig(num_proc=16),
     )
+    if world_size > 1:
+        dataset = dataset.shard(num_shards=world_size, index=rank, contiguous=True)
 
     total = 0
     total_simple = 0
     correct = 0
     correct_simple = 0
 
-    for row in tqdm(dataset, disable=args.debug):
+    for row in tqdm(dataset, disable=debug or rank != 0):
         image = row["image"]
         encoded_image = model.encode_image(image)
 
@@ -37,7 +50,7 @@ def eval_tallyqa(model, debug=False):
             total += 1
             if model_answer.strip().lower() == answer.strip().lower():
                 correct += 1
-            elif args.debug:
+            elif debug:
                 print(f"Question: {qa['question']}")
                 print(f"Answer: {answer}")
                 print(f"Model Answer: {model_answer}")
@@ -47,12 +60,21 @@ def eval_tallyqa(model, debug=False):
                 if model_answer.strip().lower() == answer.strip().lower():
                     correct_simple += 1
 
-            if args.debug:
+            if debug:
                 print(f"Simple - Correct: {correct_simple}, Total: {total_simple}")
                 print(f"Simple Accuracy: {correct_simple * 100 / total_simple:.2f}")
                 print(f"All - Correct: {correct}, Total: {total}")
                 print(f"All Accuracy: {correct * 100 / total:.2f}")
                 print("---------")
+
+    if world_size > 1:
+        counts = torch.tensor(
+            [total, correct, total_simple, correct_simple],
+            dtype=torch.long,
+            device=torch.cuda.current_device(),
+        )
+        dist.all_reduce(counts, op=dist.ReduceOp.SUM)
+        total, correct, total_simple, correct_simple = counts.tolist()
 
     return {
         "simple_acc": correct_simple * 100 / total_simple,
@@ -66,7 +88,14 @@ if __name__ == "__main__":
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
 
-    if torch.cuda.is_available():
+    # Multi-GPU: launch via
+    #   torchrun --nproc_per_node=<N> -m moondream.eval.tallyqa --model <path>
+    if "LOCAL_RANK" in os.environ and torch.cuda.is_available():
+        dist.init_process_group(backend="nccl")
+        local_rank = int(os.environ["LOCAL_RANK"])
+        torch.cuda.set_device(local_rank)
+        torch.set_default_device(f"cuda:{local_rank}")
+    elif torch.cuda.is_available():
         torch.set_default_device("cuda")
     elif torch.backends.mps.is_available():
         torch.set_default_device("mps")
@@ -78,5 +107,10 @@ if __name__ == "__main__":
 
     result = eval_tallyqa(model, args.debug)
 
-    print(f"Simple acc: {result['simple_acc']:.2f}")
-    print(f"Full acc: {result['full_acc']:.2f}")
+    _, rank = _dist_info()
+    if rank == 0:
+        print(f"Simple acc: {result['simple_acc']:.2f}")
+        print(f"Full acc: {result['full_acc']:.2f}")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.destroy_process_group()


### PR DESCRIPTION
Closes #69 (reference pattern — I'll port the other `moondream/eval/*.py` scripts in a follow-up PR once the approach here is approved).

## Approach

TallyQA eval is embarrassingly parallel per sample (no gradient sync, each row is independent), so multi-GPU is just dataset sharding plus a single `all_reduce` at the end:

1. If launched under `torchrun`, init a NCCL process group and pin each process to its local-rank device.
2. Shard the HuggingFace dataset contiguously via `dataset.shard(world_size, rank)`.
3. Each rank runs the existing eval loop on its shard.
4. `all_reduce` the four counters (`total`, `correct`, `total_simple`, `correct_simple`); compute accuracies on rank 0.

No new dependencies — just `torch.distributed`, which ships with torch.

## Usage

Single GPU / CPU / MPS (unchanged):
```
python -m moondream.eval.tallyqa --model <path>
```

Multi-GPU:
```
torchrun --nproc_per_node=<N> -m moondream.eval.tallyqa --model <path>
```

The distributed path only activates when `LOCAL_RANK` is set in the environment (i.e. the process was launched by `torchrun`), so existing single-GPU invocations behave exactly as before.

## Notes

- Progress bar and final `print` only run on rank 0 to keep stdout clean.
- `dist.destroy_process_group()` is called on shutdown to avoid NCCL exit warnings.
- Drive-by: switched the three `args.debug` references inside `eval_tallyqa` to the `debug` parameter it already accepts — this means `eval_all.py` can call it without leaking module globals. Happy to split this into a separate commit/PR if preferred.

## Test plan

- [x] Syntax-checks and passes `black --check`.
- [x] Single-GPU path: no changes to control flow when `LOCAL_RANK` is unset.
- [x] Multi-GPU smoke test on 2× T4 (Modal). To isolate the distributed plumbing from model correctness, I ran the eval with a stubbed model (counts its own calls, returns a fixed answer) on the first 40 dataset samples. Results: single-GPU processed 126 QAs; 2-GPU sharded into 79 + 47 = 126 (full coverage, no overlap); accuracies matched exactly between both runs (Simple 36.29%, Full 36.51%); the rank-0-gated final prints appeared exactly once in the 2-GPU output. This directly exercises `dist.init_process_group`, `dataset.shard(contiguous=True)`, `dist.all_reduce`, and the rank-0 print guards.

Once this pattern is accepted I'll port the other eval scripts (`pope.py`, `chartqa.py`, `textvqa.py`, `docvqa.py`, `mmstar.py`, `coco_map.py`, `naturalbench.py`, `countbenchqa.py`, `realworldqa.py`) and update `eval_all.py` in a follow-up.
