### PR TITLE
fix: make torch.cuda.empty_cache() and flex_attention device-agnostic (Intel XPU, Apple MPS)

### DIFF
--- a/moondream/torch/layers.py
+++ b/moondream/torch/layers.py
@@ -101,7 +101,12 @@ class QuantizedLinear(nn.Module):
         del self.weight, self.bias
         quantize_(self, int4_weight_only(group_size=128))
         self.unpacked = True
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        elif hasattr(torch, "xpu") and torch.xpu.is_available():
+            torch.xpu.empty_cache()
+        elif hasattr(torch, "mps") and torch.mps.is_available():
+            torch.mps.empty_cache()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if not self.unpacked:

--- a/moondream/torch/moondream.py
+++ b/moondream/torch/moondream.py
@@ -93,7 +93,11 @@ def get_mask_mod(mask_mod, offset):
 class MoondreamModel(nn.Module):
 
     def __init__(
-        self, config: MoondreamConfig, dtype=torch.bfloat16, setup_caches=True
+        self,
+        config: MoondreamConfig,
+        dtype=torch.bfloat16,
+        setup_caches=True,
+        use_flex_decoding=None,
     ):
         super().__init__()
         self.config = config
@@ -139,7 +143,9 @@ class MoondreamModel(nn.Module):
         attn_mask[..., :prefix_attn_len, :prefix_attn_len] = 1
         self.register_buffer("attn_mask", attn_mask, persistent=False)
 
-        self.use_flex_decoding = True
+        if use_flex_decoding is None:
+            use_flex_decoding = torch.cuda.is_available()
+        self.use_flex_decoding = use_flex_decoding
         self._causal_block_mask = None
         self._point_gen_indices = None
 

--- a/moondream/torch/sample.py
+++ b/moondream/torch/sample.py
@@ -38,9 +38,10 @@ if __name__ == "__main__":
     model.to(device, dtype=torch.bfloat16)
     model.compile()
 
-    torch.cuda.empty_cache()
-    torch.cuda.reset_peak_memory_stats()
-    torch.cuda.reset_accumulated_memory_stats()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.reset_accumulated_memory_stats()
 
     # Encode image.
     image_path = args.image


### PR DESCRIPTION
## Problem

Moondream3-preview crashes on non-CUDA devices (Intel Arc GPU, Apple MPS, AMD ROCm) due to two CUDA-specific code paths:

### 1. `torch.cuda.empty_cache()` crashes in production model code
`QuantizedLinear.unpack()` calls `torch.cuda.empty_cache()` unconditionally. On Intel XPU and Apple MPS, this raises RuntimeError or AttributeError.

### 2. `flex_attention` + `create_block_mask` is CUDA-only (fixes #316)
`MoondreamModel.__init__` hardcodes `self.use_flex_decoding = True`, triggering `create_block_mask` and `flex_attention` imports that are CUDA-only APIs.

## Changes

### `layers.py` — Device-agnostic cache clearing
```python
# Before:
torch.cuda.empty_cache()

# After:
if torch.cuda.is_available():
    torch.cuda.empty_cache()
elif hasattr(torch, "xpu") and torch.xpu.is_available():
    torch.xpu.empty_cache()
elif hasattr(torch, "mps") and torch.mps.is_available():
    torch.mps.empty_cache()
```

### `moondream.py` — Configurable flex_decoding with auto-detection
```python
# New constructor parameter with smart default:
def __init__(self, config, ..., use_flex_decoding=None):
    if use_flex_decoding is None:
        use_flex_decoding = torch.cuda.is_available()  # auto-detect
    self.use_flex_decoding = use_flex_decoding
```
- **CUDA users:** No change — flex_decoding auto-enabled ✓
- **Intel XPU / Apple MPS:** flex_decoding auto-disabled, falls back to `F.scaled_dot_product_attention` ✓
- **Power users:** Can override: `MoondreamModel(config, use_flex_decoding=False)`

### `sample.py` — Guard benchmark memory stats
CUDA-specific memory stat calls gated behind `torch.cuda.is_available()`.

## Why this approach (vs alternatives)

- **Auto-detection** means the model "just works" on Intel, Apple, and AMD without manual configuration
- **Explicit override** preserves flexibility for users who want to force flex_attention on platforms with experimental support
- **Three-backend cache clearing** covers CUDA, XPU, and MPS — the three major PyTorch backends
- **Minimal diff** (18 insertions, 6 deletions) — only touches the exact call sites that crash

## Testing

Tested on Intel Arc A770 with PyTorch 2.6.0+xpu (Intel oneAPI 2025.0.2):
- ✅ Model loads without CUDA errors
- ✅ `use_flex_decoding` auto-set to `False`
- ✅ `QuantizedLinear.unpack()` calls `torch.xpu.empty_cache()` correctly
- ✅ Inference works via `F.scaled_dot_product_attention` fallback

## Related
- Fixes #316 (Apple MPS — same `use_flex_decoding` issue)
- Fixes #335 (Intel Arc GPU — `torch.cuda.empty_cache()` + flex_attention)
- Complements PR #326 (adds constructor param — this PR also adds auto-detection + cache fix)