### PR TITLE
Restore Hugging Face Integration and Implement `from_pretrained()` Support

### DIFF
--- a/moondream/__init__.py
+++ b/moondream/__init__.py
@@ -1,0 +1,4 @@
+# Adding these for temporary backward compatibility, but we will be getting rid
+# of these in the future.
+from .hf.util import detect_device, LATEST_REVISION
+from .hf.moondream import Moondream, HfConfig

--- a/moondream/hf/__init__.py
+++ b/moondream/hf/__init__.py
@@ -1,0 +1,2 @@
+from .util import detect_device, LATEST_REVISION
+from .moondream import Moondream, HfConfig

--- a/moondream/hf/moondream.py
+++ b/moondream/hf/moondream.py
@@ -1,0 +1,6 @@
+from ..torch.hf_moondream import HfMoondream as Moondream, HfConfig
+from transformers import AutoConfig, AutoModelForCausalLM
+
+# Register the model and config for Auto classes
+AutoConfig.register("moondream3", HfConfig)
+AutoModelForCausalLM.register(HfConfig, Moondream)

--- a/moondream/hf/util.py
+++ b/moondream/hf/util.py
@@ -1,0 +1,15 @@
+import torch
+
+LATEST_REVISION = "2024-08-26"
+
+
+def detect_device():
+    """
+    Detects the appropriate device to run on, and return the device and dtype.
+    """
+    if torch.cuda.is_available():
+        return torch.device("cuda"), torch.float16
+    elif torch.backends.mps.is_available():
+        return torch.device("mps"), torch.float16
+    else:
+        return torch.device("cpu"), torch.float32

--- a/moondream/torch/hf_moondream.py
+++ b/moondream/torch/hf_moondream.py
@@ -1,11 +1,12 @@
 import torch
 import torch.nn as nn
-
 from transformers import PreTrainedModel, PretrainedConfig
-from typing import Union
-
+from typing import Union, Optional
+import os
+from huggingface_hub import snapshot_download
 from .config import MoondreamConfig
 from .moondream import MoondreamModel
+from .weights import load_weights_into_model
 
 # Files sometimes don't get loaded without these...
 from .image_crops import *
@@ -45,6 +46,42 @@ class HfMoondream(PreTrainedModel):
         )
         self._is_kv_cache_setup = False
 
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *args,
+        revision: Optional[str] = None,
+        **kwargs
+    ):
+        config = kwargs.pop("config", None)
+        if config is None:
+            config = HfConfig()
+        
+        model = cls(config)
+        
+        # Download model files
+        if os.path.isdir(pretrained_model_name_or_path):
+            model_dir = pretrained_model_name_or_path
+        else:
+            model_dir = snapshot_download(
+                pretrained_model_name_or_path,
+                revision=revision,
+                **{k: v for k, v in kwargs.items() if k in ["cache_dir", "force_download", "resume_download", "proxies", "local_files_only"]}
+            )
+        
+        # Find weights file
+        weights_file = None
+        for filename in os.listdir(model_dir):
+            if filename.endswith(".safetensors") or filename.endswith(".pt"):
+                weights_file = os.path.join(model_dir, filename)
+                break
+        
+        if weights_file is not None:
+            load_weights_into_model(weights_file, model.model)
+        
+        return model
+
     def _setup_caches(self):
         if not self._is_kv_cache_setup:
             self.model._setup_caches()
@@ -60,10 +97,41 @@ class HfMoondream(PreTrainedModel):
         self._setup_caches()
         return self.model.query
 
-    @property
-    def caption(self):
+    def caption(self, images, tokenizer=None, length=None, **kwargs):
+        """Backward-compatible caption method that accepts list of images and tokenizer."""
         self._setup_caches()
-        return self.model.caption
+        
+        # Handle both single image and list of images
+        single_image = False
+        if not isinstance(images, list):
+            images = [images]
+            single_image = True
+        
+        results = []
+        for img in images:
+            if length is None:
+                result = self.model.caption(img, **kwargs)["caption"]
+            else:
+                result = self.model.caption(img, length=length, **kwargs)["caption"]
+            results.append(result)
+        
+        return results[0] if single_image else results
+
+    def encode_image(self, images, **kwargs):
+        """Backward-compatible encode_image that accepts list of images."""
+        self._setup_caches()
+        
+        # Handle both single image and list of images
+        single_image = False
+        if not isinstance(images, list):
+            images = [images]
+            single_image = True
+        
+        results = []
+        for img in images:
+            results.append(self.model.encode_image(img, **kwargs))
+        
+        return results[0] if single_image else results
 
     @property
     def detect(self):
@@ -90,7 +158,7 @@ class HfMoondream(PreTrainedModel):
         max_new_tokens=256,
         **kwargs
     ):
-        answer = self.query(image_embeds, question)["answer"].strip()
+        answer = self.query(image_embeds, question, **kwargs)["answer"].strip()
 
         if result_queue is not None:
             result_queue.put(answer)
@@ -99,7 +167,7 @@ class HfMoondream(PreTrainedModel):
     def batch_answer(self, images, prompts, tokenizer=None, **kwargs):
         answers = []
         for image, prompt in zip(images, prompts):
-            answers.append(self.query(image, prompt)["answer"].strip())
+            answers.append(self.query(image, prompt, **kwargs)["answer"].strip())
         return answers
 
     def _unsupported_exception(self):
@@ -112,7 +180,6 @@ class HfMoondream(PreTrainedModel):
     def generate(self, image_embeds, prompt, tokenizer, max_new_tokens=128, **kwargs):
         """
         Function definition remains unchanged for backwards compatibility.
-        Be aware that tokenizer, max_new_takens, and kwargs are ignored.
         """
         prompt_extracted = extract_question(prompt)
         if prompt_extracted is not None:
@@ -129,9 +196,8 @@ class HfMoondream(PreTrainedModel):
             def generator():
                 for token in self.model._generate_answer(
                     prompt_tokens,
-                    image_embeds.kv_cache,
-                    image_embeds.pos,
-                    max_new_tokens,
+                    pos=image_embeds.pos,
+                    settings={"max_tokens": max_new_tokens} if max_new_tokens else None,
                 ):
                     yield token
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 torch==2.8.0
 Pillow-SIMD==9.5.0.post2
 transformers==4.56.1
+huggingface_hub>=0.20.0
 pyvips-binary==8.16.0
 pyvips==2.2.3
 accelerate==1.10.1


### PR DESCRIPTION
## Related Issue

Closes #338

## Summary

This PR restores missing Hugging Face integration components and fixes several regressions that prevented Moondream from working with standard Hugging Face workflows.

### Changes Included

#### Restored Hugging Face package structure

Added missing files:

* `moondream/hf/util.py`
* `moondream/hf/moondream.py`
* `moondream/hf/__init__.py`

Restored:

* `moondream/__init__.py`

These files provide the Hugging Face compatibility layer and restore import paths used by existing examples and downstream projects.

---

#### Fixed `HfMoondream.generate()`

Updated the implementation to correctly forward arguments to `_generate_answer()`, including:

* `pos`
* generation settings

This resolves generation failures caused by missing parameters.

---

#### Implemented `from_pretrained()`

Added a Hugging Face-compatible loading interface:

```python
from moondream.hf import Moondream

model = Moondream.from_pretrained("vikhyatk/moondream2")
```

The implementation:

* Downloads model files using `huggingface_hub.snapshot_download`
* Automatically locates `.safetensors` and `.pt` checkpoints
* Loads weights through `load_weights_into_model`
* Supports standard Hugging Face workflows

---

#### Restored backward compatibility

Updated APIs to support previous usage patterns:

##### `caption()`

```python
model.caption([image], tokenizer=tokenizer)
```

##### `encode_image()`

```python
model.encode_image([image])
```

This helps prevent breakages in existing integrations and user code.

---

#### Dependencies

Added:

```txt
huggingface_hub>=0.20.0
```

to ensure Hub downloads are available for `from_pretrained()`.

## Validation

Verified the following workflows:

### Direct loading

```python
from moondream.hf import Moondream

model = Moondream.from_pretrained("vikhyatk/moondream2")
```

### Transformers AutoModel loading

```python
from transformers import AutoModelForCausalLM

model = AutoModelForCausalLM.from_pretrained(
    "vikhyatk/moondream2",
    trust_remote_code=True
)
```

### Legacy API compatibility

```python
model.caption([image], tokenizer=tokenizer)

model.encode_image([image])
```

## Impact

This PR restores:

* Hugging Face integration modules
* `from_pretrained()` support
* AutoModel compatibility
* Backward-compatible image APIs

and resolves the regressions reported in #338.