### PR TITLE
feat(torch): allow disabling flex decoding at construction

### DIFF
--- a/moondream/torch/hf_moondream.py
+++ b/moondream/torch/hf_moondream.py
@@ -38,10 +38,12 @@ class HfMoondream(PreTrainedModel):
     _auto_class = "AutoModelForCausalLM"
     config_class = HfConfig
 
-    def __init__(self, config):
+    def __init__(self, config, use_flex_decoding=True):
         super().__init__(config)
         self.model = MoondreamModel(
-            MoondreamConfig.from_dict(config.config), setup_caches=False
+            MoondreamConfig.from_dict(config.config),
+            setup_caches=False,
+            use_flex_decoding=use_flex_decoding,
         )
         self._is_kv_cache_setup = False
 

--- a/moondream/torch/moondream.py
+++ b/moondream/torch/moondream.py
@@ -93,7 +93,11 @@ def get_mask_mod(mask_mod, offset):
 class MoondreamModel(nn.Module):
 
     def __init__(
-        self, config: MoondreamConfig, dtype=torch.bfloat16, setup_caches=True
+        self,
+        config: MoondreamConfig,
+        dtype=torch.bfloat16,
+        setup_caches=True,
+        use_flex_decoding=True,
     ):
         super().__init__()
         self.config = config
@@ -139,7 +143,7 @@ class MoondreamModel(nn.Module):
         attn_mask[..., :prefix_attn_len, :prefix_attn_len] = 1
         self.register_buffer("attn_mask", attn_mask, persistent=False)
 
-        self.use_flex_decoding = True
+        self.use_flex_decoding = use_flex_decoding
         self._causal_block_mask = None
         self._point_gen_indices = None
 
@@ -235,7 +239,8 @@ class MoondreamModel(nn.Module):
                 module.unpack()
 
         # Initialize lazy properties to avoid first-call overhead
-        self.causal_block_mask
+        if self.use_flex_decoding:
+            self.causal_block_mask
         self.point_gen_indices
 
         # TODO: vision_projection and _prefill is not being compiled


### PR DESCRIPTION
Fixes #316

\use_flex_decoding\ was hardcoded to \True\ and could only be toggled after the model was fully built, by which point CUDA-only \create_block_mask\ had already been invoked (e.g. during \compile()\ warmup, breaking MPS/CPU users).

Changes:
- \MoondreamModel.__init__\ now accepts \use_flex_decoding\ (default \True\)
- \HfMoondream.__init__\ forwards the flag so \rom_pretrained\ consumers control it up front
- \compile()\ only builds the flex block mask when flex decoding is enabled

This lets non-CUDA users construct with \use_flex_decoding=False\ from the start, matching the suggestion in the issue. Note: the low-level \create_block_mask\ import remains at module scope for CUDA users who keep it enabled.