### PR TITLE
fix: guard BlockMask seq_lengths for torch < 2.6 compatibility

### DIFF
--- a/moondream/torch/moondream.py
+++ b/moondream/torch/moondream.py
@@ -212,7 +212,8 @@ class MoondreamModel(nn.Module):
             torch._assert(pos_ids.shape[-1] == 1, "Invalid position ID shape")
             block_index = pos_ids // self.causal_block_mask.BLOCK_SIZE[0]
             mask = self.causal_block_mask[:, :, block_index]
-            mask.seq_lengths = (1, mask.seq_lengths[1])
+            if hasattr(mask, "seq_lengths"):
+                mask.seq_lengths = (1, mask.seq_lengths[1])
             mask.mask_mod = get_mask_mod(self.causal_block_mask.mask_mod, pos_ids[0])
         else:
             mask = None


### PR DESCRIPTION
Fixes #320

## Problem

Inference on Moondream 3 crashes with:

\\\
AttributeError: 'BlockMask' object has no attribute 'seq_lengths'
\\\

at \_decode_one_tok\ in \moondream/torch/moondream.py\:

\\\python
mask.seq_lengths = (1, mask.seq_lengths[1])
\\\

The \seq_lengths\ attribute was only added to \	orch.nn.attention.flex_attention.BlockMask\ in torch 2.6.0. On torch 2.5.x (e.g. 2.5.1+cu124, as reported in #314 and #320) the sliced block mask has no such attribute, so reading \mask.seq_lengths[1]\ raises \AttributeError\ during decoding.

## Fix

Guard the \seq_lengths\ adjustment with \hasattr\:

- torch >= 2.6: \seq_lengths\ is adjusted to \(1, kv_len)\ as before (behavior unchanged).
- torch 2.5.x: the adjustment is skipped; flex_attention on 2.5 does not validate the mask's sequence lengths, so decoding works with the sliced block mask directly.

## Verification

Verified against mock BlockMask objects mimicking both the torch 2.5.x (no \seq_lengths\) and torch 2.6+ (with \seq_lengths\) APIs:
- 2.5-style mask: previously raised AttributeError, now succeeds.
- 2.6+-style mask: still adjusts \seq_lengths\ to \(1, 4096)\ exactly as before.