### PR TITLE
fix: use debug parameter instead of undefined args global in tallyqa eval

### DIFF
--- a/moondream/eval/tallyqa.py
+++ b/moondream/eval/tallyqa.py
@@ -23,7 +23,7 @@ def eval_tallyqa(model, debug=False):
     correct = 0
     correct_simple = 0
 
-    for row in tqdm(dataset, disable=args.debug):
+    for row in tqdm(dataset, disable=debug):
         image = row["image"]
         encoded_image = model.encode_image(image)
 
@@ -37,7 +37,7 @@ def eval_tallyqa(model, debug=False):
             total += 1
             if model_answer.strip().lower() == answer.strip().lower():
                 correct += 1
-            elif args.debug:
+            elif debug:
                 print(f"Question: {qa['question']}")
                 print(f"Answer: {answer}")
                 print(f"Model Answer: {model_answer}")
@@ -47,7 +47,7 @@ def eval_tallyqa(model, debug=False):
                 if model_answer.strip().lower() == answer.strip().lower():
                     correct_simple += 1
 
-            if args.debug:
+            if debug:
                 print(f"Simple - Correct: {correct_simple}, Total: {total_simple}")
                 print(f"Simple Accuracy: {correct_simple * 100 / total_simple:.2f}")
                 print(f"All - Correct: {correct}, Total: {total}")


### PR DESCRIPTION
Fixes the eval harness used by `moondream/eval/eval_all.py` (see #69).

## Problem

`eval_tallyqa(model, debug=False)` in `moondream/eval/tallyqa.py` references the module-level global `args` (`args.debug`) even though `args` only exists inside the `if __name__ == "__main__"` block.

Running tallyqa standalone works by accident (the global exists), but importing and calling it from another module — exactly what `eval_all.py` does via `evals["tallyqa"] = eval_tallyqa` → `eval_fn(model)` — raises:

```
NameError: name 'args' is not defined
```

so the full evaluation suite crashes as soon as it reaches the tallyqa benchmark.

## Fix

Use the `debug` parameter instead of the undefined `args` global (3 occurrences). This matches the pattern used by every other eval script (`eval_countbenchqa`, `eval_chartqa`, `eval_mmstar`, etc.).

## Verification

Reproduced the `NameError` with a minimal simulation of the function's code and confirmed it no longer occurs after the change.