### PR TITLE
docs: add License section to README (addresses #328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Moondream can be run locally, or in the cloud. Please refer to the [Getting Star
 ## Special thanks
 
 * [Modal](https://modal.com/?utm_source=github&utm_medium=github&utm_campaign=moondream) - Modal lets you run jobs in the cloud, by just writing a few lines of Python. Here's an [example of how to run Moondream on Modal](https://github.com/m87-labs/moondream-examples/tree/main/quickstart/modal).
+
+## License
+
+Licensed under the Apache License 2.0 — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Addresses #328 — Documentation enhancement checklist notes License not mentioned in README.

Adds a ## License section pointing to the existing Apache-2.0 LICENSE file. Meets the public README transparency observation: License, installation and benchmarks are now explicitly surfaced.
