### PR TITLE
docs: fix hyphenation 'vision-language model'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌔 moondream
 
-a tiny vision language model that kicks ass and runs anywhere
+a tiny vision-language model that kicks ass and runs anywhere
 
 [Website](https://moondream.ai/) | [Demo](https://moondream.ai/playground)
 
@@ -13,7 +13,7 @@ a tiny vision language model that kicks ass and runs anywhere
 
 ## About
 
-Moondream is a highly efficient open-source vision language model that combines powerful image understanding capabilities with a remarkably small footprint. It's designed to be versatile and accessible, capable of running on a wide range of devices and platforms.
+Moondream is a highly efficient open-source vision-language model that combines powerful image understanding capabilities with a remarkably small footprint. It's designed to be versatile and accessible, capable of running on a wide range of devices and platforms.
 
 The project offers two model variants:
 


### PR DESCRIPTION
Fixes hyphenation: 'vision language model' -> 'vision-language model' when used as compound adjective.