### PR TITLE
docs: fix incorrect path in Python quickstart

### DIFF
--- a/examples/quickstart/python/README.md
+++ b/examples/quickstart/python/README.md
@@ -15,7 +15,7 @@ Get started with Moondream's vision AI in Python in minutes.
    pip install -r requirements.txt
    ```
 
-3. Run Moondream Station locally or tweak the [main.py](quickstart/python/main.py) or run on the cloud using an [API key](https://moondream.ai/c/cloud/api-keys).
+3. Run Moondream Station locally or tweak the [main.py](main.py) or run on the cloud using an [API key](https://moondream.ai/c/cloud/api-keys).
 
 4. Run the example to see Moondream in action!
 


### PR DESCRIPTION
Fix path quickstart/python/main.py -> main.py (relative to quickstart/python directory).