### PR TITLE
docs: document MOONDREAM_API_KEY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,33 @@ The project offers two model variants:
 
 Moondream can be run locally, or in the cloud. Please refer to the [Getting Started](https://moondream.ai/c/docs/quickstart) page for details.
 
+## Configuration
+
+Set your Moondream API key via the `MOONDREAM_API_KEY` environment variable
+instead of hardcoding it:
+
+```shell
+export MOONDREAM_API_KEY="<your-api-key>"
+```
+
+```python
+import moondream as md
+import os
+
+# For Moondream Cloud, the client reads MOONDREAM_API_KEY from the environment:
+model = md.vl(api_key=os.environ.get("MOONDREAM_API_KEY"))
+```
+
+To point at a custom endpoint (e.g. a local server), set `MOONDREAM_ENDPOINT`
+(defaults to `https://api.moondream.ai`):
+
+```shell
+export MOONDREAM_ENDPOINT="http://localhost:2020/v1"
+```
+
+> Never commit API keys to version control. Use environment variables or your
+> platform's secrets manager, and scope keys to the minimum access needed.
+
 ## Special thanks
 
 * [Modal](https://modal.com/?utm_source=github&utm_medium=github&utm_campaign=moondream) - Modal lets you run jobs in the cloud, by just writing a few lines of Python. Here's an [example of how to run Moondream on Modal](https://github.com/m87-labs/moondream-examples/tree/main/quickstart/modal).

--- a/examples/quickstart/python/main.py
+++ b/examples/quickstart/python/main.py
@@ -1,11 +1,13 @@
 import moondream as md
 from PIL import Image
+import os
 
 # This will run the model locally
 model = md.vl(endpoint="http://localhost:2020/v1")
 
-# For Moondream Cloud, use your API key:
-# model = md.vl(api_key="<your-api-key>")
+# For Moondream Cloud, use your API key from the MOONDREAM_API_KEY
+# environment variable instead of hardcoding it:
+# model = md.vl(api_key=os.environ.get("MOONDREAM_API_KEY"))
 
 # Load an image
 image = Image.open("../../images/frieren.jpg")


### PR DESCRIPTION
Fixes #288.

Adds a Configuration section to the README documenting MOONDREAM_API_KEY (with a security note) and MOONDREAM_ENDPOINT, and updates the Python quickstart to read the key from the environment instead of hardcoding it. No code changes needed: moondream/torch/lora.py already reads both variables; only the docs were missing.