### PR TITLE
docs: fix Node quickstart run command

### DIFF
--- a/examples/quickstart/node/README.md
+++ b/examples/quickstart/node/README.md
@@ -20,5 +20,5 @@ Get started with Moondream's vision AI in Node in minutes.
 4. Run the examples to see Moondream in action!
 
    ```bash
-   node main.py
+   node main.js
    ```


### PR DESCRIPTION
docs: fix Node quickstart run command

The Node quickstart dir ships main.js (no main.py exists); line 18 itself references main.js. Running the documented command fails with Cannot find module. Fixes the copy-paste from the Python quickstart.
