### PR TITLE
docs: fix unclonable recipe clone URLs

### DIFF
--- a/recipes/promptable-content-moderation/README.md
+++ b/recipes/promptable-content-moderation/README.md
@@ -60,7 +60,8 @@ Installation by platform:
 1. Clone this repository and create a new virtual environment:
 
 ```bash
-git clone https://github.com/vikhyat/moondream/blob/main/recipes/promptable-video-redaction
+git clone https://github.com/m87-labs/moondream.git
+cd moondream/recipes/promptable-content-moderation
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```

--- a/recipes/promptable-video-redaction/README.md
+++ b/recipes/promptable-video-redaction/README.md
@@ -54,7 +54,8 @@ Links:
 1. Clone this repository and create a new virtual environment
 
 ```bash
-git clone https://github.com/vikhyat/moondream/blob/main/recipes/promptable-video-redaction
+git clone https://github.com/m87-labs/moondream.git
+cd moondream/recipes/promptable-video-redaction
 python -m venv .venv
 source .venv/bin/activate
 ```


### PR DESCRIPTION
docs: fix unclonable recipe clone URLs

Both recipes used a GitHub web-UI path (/blob/main/...) as a git clone endpoint, which always fails. Point at the current org repo and cd into the recipe dir. Also fixes a copy-paste where the content-moderation README cloned the video-redaction path.
