### PR TITLE
docs: fill gaze recipe Windows clone placeholder

### DIFF
--- a/recipes/gaze-detection-video/README.md
+++ b/recipes/gaze-detection-video/README.md
@@ -83,7 +83,7 @@ Windows setup requires a few additional steps for proper GPU support and libvips
 1. Clone the repository:
 
    ```bash
-   git clone [repository-url]
+   git clone https://github.com/m87-labs/moondream.git
    cd moondream/recipes/gaze-detection-video
    ```
 


### PR DESCRIPTION
docs: fill gaze recipe Windows clone placeholder

The Windows section left git clone [repository-url] as a template placeholder while Linux just above has a real URL. Fill it with the current org repo so the steps work verbatim.
