### PR TITLE
docs: point quickstarts at existing demo-1.jpg asset

### DIFF
--- a/examples/quickstart/bash/main.sh
+++ b/examples/quickstart/bash/main.sh
@@ -4,7 +4,7 @@
 curl --location "http://localhost:2020/v1/{endpoint}" \
   --header 'Content-Type: application/json' \
   --data '{
-    "image_url": "data:image/jpeg;base64,${cat ../images/frieren.jpg | base64}",
+    "image_url": "data:image/jpeg;base64,${cat ../../../assets/demo-1.jpg | base64}",
     "stream": false
   }'
 
@@ -13,6 +13,6 @@ curl --location "http://localhost:2020/v1/{endpoint}" \
 #   --header 'X-Moondream-Auth: ${MOONDREAM_API_KEY}' \
 #   --header 'Content-Type: application/json' \
 #   --data '{
-#     "image_url": "data:image/jpeg;base64,${cat ../images/frieren.jpg | base64}",
+#     "image_url": "data:image/jpeg;base64,${cat ../../../assets/demo-1.jpg | base64}",
 #     "stream": false
 #   }'

--- a/examples/quickstart/modal/modal_infer.py
+++ b/examples/quickstart/modal/modal_infer.py
@@ -6,7 +6,7 @@ from PIL import Image
 # Replace <username> with your actual username on modal labs.
 model = md.vl(endpoint="https://<username>--moondream-server.modal.run/v1")
 
-image = Image.open("../../images/frieren.jpg")
+image = Image.open("../../../assets/demo-1.jpg")
 
 # Query
 print("Query:")

--- a/examples/quickstart/node/main.js
+++ b/examples/quickstart/node/main.js
@@ -8,7 +8,7 @@ const model = new vl({ endpoint: "http://localhost:2020/v1" });
 // const model = new vl({ apiKey: "<your-api-key>" });
 
 // read the image we're going to use
-const image = fs.readFileSync("../images/frieren.jpg");
+const image = fs.readFileSync("../../../assets/demo-1.jpg");
 
 async function main() {
   // let's generate a caption for the image

--- a/examples/quickstart/python/main.py
+++ b/examples/quickstart/python/main.py
@@ -8,7 +8,7 @@ model = md.vl(endpoint="http://localhost:2020/v1")
 # model = md.vl(api_key="<your-api-key>")
 
 # Load an image
-image = Image.open("../../images/frieren.jpg")
+image = Image.open("../../../assets/demo-1.jpg")
 
 # Example: Generate a caption
 caption_response = model.caption(image, length="short")


### PR DESCRIPTION
docs: point quickstarts at existing demo-1.jpg asset

python, modal, node and bash quickstarts referenced ../../images/frieren.jpg (and ../images/ variant) which was never carried over from moondream-examples - no images/ dir exists in this repo. Point all four at the in-repo assets/demo-1.jpg with the correct relative depth.
