### PR TITLE
docs: fix stale recipe links (owner + https)

### DIFF
--- a/recipes/gaze-detection-video/README.md
+++ b/recipes/gaze-detection-video/README.md
@@ -69,7 +69,7 @@ This project uses the Moondream 2B model to detect faces and their gaze directio
 
 2. Clone and setup the project:
    ```bash
-   git clone https://github.com/vikhyat/moondream.git
+    git clone https://github.com/m87-labs/moondream.git
    cd moondream/recipes/gaze-detection-video
    python3 -m venv venv
    source venv/bin/activate

--- a/recipes/promptable-video-redaction/README.md
+++ b/recipes/promptable-video-redaction/README.md
@@ -20,7 +20,7 @@ Links:
 
 - [GitHub Repository](https://github.com/vikhyat/moondream)
 - [Hugging Face](https://huggingface.co/vikhyatk/moondream2)
-- [Build with Moondream](http://docs.moondream.ai/)
+- [Build with Moondream](https://docs.moondream.ai/)
 
 ## Features
 


### PR DESCRIPTION
docs: fix stale recipe links (owner + https)

- gaze-detection-video Linux/macOS clone: vikhyat/moondream -> m87-labs/moondream (matches Windows section + prior recipe fixes)
- promptable-video-redaction docs link: http:// -> https://docs.moondream.ai/.
