### PR TITLE
docs: fix stale vikhyat owner links in recipes

### DIFF
--- a/recipes/promptable-content-moderation/app.py
+++ b/recipes/promptable-content-moderation/app.py
@@ -374,7 +374,7 @@ with gr.Blocks(title="Promptable Content Moderation") as app:
             gr.Markdown("# Promptable Content Moderation with Moondream")
             gr.Markdown(
                 """
-            Powered by [Moondream 2B](https://github.com/vikhyat/moondream).
+            Powered by [Moondream 2B](https://github.com/m87-labs/moondream).
 
             Upload a video and specify what to moderate. The app will process each frame and moderate any visual content that matches the prompt. For help, join the [Moondream Discord](https://discord.com/invite/tRUdpjDQfH).
             """
@@ -477,7 +477,7 @@ with gr.Blocks(title="Promptable Content Moderation") as app:
                     gr.Markdown(
                         """
                     ### Links:
-                    - [GitHub Repository](https://github.com/vikhyat/moondream)
+                    - [GitHub Repository](https://github.com/m87-labs/moondream)
                     - [Hugging Face](https://huggingface.co/vikhyatk/moondream2)
                     - [Quick Start](https://docs.moondream.ai/quick-start)
                     - [Moondream Recipes](https://docs.moondream.ai/recipes)

--- a/recipes/promptable-video-redaction/README.md
+++ b/recipes/promptable-video-redaction/README.md
@@ -18,7 +18,7 @@ accuracy. Some key features:
 
 Links:
 
-- [GitHub Repository](https://github.com/vikhyat/moondream)
+- [GitHub Repository](https://github.com/m87-labs/moondream)
 - [Hugging Face](https://huggingface.co/vikhyatk/moondream2)
 - [Build with Moondream](http://docs.moondream.ai/)
 

--- a/recipes/promptable-video-redaction/app.py
+++ b/recipes/promptable-video-redaction/app.py
@@ -96,7 +96,7 @@ with gr.Blocks(title="Promptable Video Redaction") as app:
     gr.Markdown("# Promptable Video Redaction with Moondream")
     gr.Markdown(
         """
-    [Moondream 2B](https://github.com/vikhyat/moondream) is a lightweight vision model that detects and visualizes objects in videos. It can identify objects, people, text and more.
+    [Moondream 2B](https://github.com/m87-labs/moondream) is a lightweight vision model that detects and visualizes objects in videos. It can identify objects, people, text and more.
 
     Upload a video and specify what to detect. The app will process each frame and apply your chosen visualization style. For help, join the [Moondream Discord](https://discord.com/invite/tRUdpjDQfH).
     """
@@ -171,7 +171,7 @@ with gr.Blocks(title="Promptable Video Redaction") as app:
             gr.Markdown(
                 """
             ### Links:
-            - [GitHub Repository](https://github.com/vikhyat/moondream)
+            - [GitHub Repository](https://github.com/m87-labs/moondream)
             - [Hugging Face](https://huggingface.co/vikhyatk/moondream2)
             - [Python Package](https://pypi.org/project/moondream/)
             - [Moondream Recipes](https://docs.moondream.ai/recipes)


### PR DESCRIPTION
The org moved to m87-labs but 5 recipe links still point at github.com/vikhyat/moondream (follows the precedent of #386).

Changed:
- recipes/promptable-video-redaction/README.md (GitHub Repository link)
- recipes/promptable-video-redaction/app.py (Moondream 2B + GitHub Repository links)
- recipes/promptable-content-moderation/app.py (Moondream 2B + GitHub Repository links)

huggingface.co/vikhyatk links deliberately untouched (live HF namespace).
