### PR TITLE
docs: fix dead libvips quick-start links in recipes

### DIFF
--- a/recipes/promptable-content-moderation/README.md
+++ b/recipes/promptable-content-moderation/README.md
@@ -53,7 +53,7 @@ Installation by platform:
 - macOS: `brew install ffmpeg libvips`
 - Windows:
   - Download FFmpeg from [ffmpeg.org](https://ffmpeg.org/download.html)
-  - Follow [libvips Windows installation guide](https://docs.moondream.ai/quick-start)
+  - Follow [libvips Windows installation guide](https://moondream.ai/c/docs/quickstart)
 
 ## Installation
 
@@ -76,7 +76,7 @@ pip install -r requirements.txt
    - On macOS: `brew install ffmpeg`
    - On Windows: Download from [ffmpeg.org](https://ffmpeg.org/download.html)
 
-> Downloading libvips for Windows requires some additional steps, see [here](https://docs.moondream.ai/quick-start)
+> Downloading libvips for Windows requires some additional steps, see [here](https://moondream.ai/c/docs/quickstart)
 
 ## Usage
 

--- a/recipes/promptable-content-moderation/app.py
+++ b/recipes/promptable-content-moderation/app.py
@@ -479,7 +479,7 @@ with gr.Blocks(title="Promptable Content Moderation") as app:
                     ### Links:
                     - [GitHub Repository](https://github.com/vikhyat/moondream)
                     - [Hugging Face](https://huggingface.co/vikhyatk/moondream2)
-                    - [Quick Start](https://docs.moondream.ai/quick-start)
+                    - [Quick Start](https://moondream.ai/c/docs/quickstart)
                     - [Moondream Recipes](https://docs.moondream.ai/recipes)
                     """
                     )

--- a/recipes/promptable-video-redaction/README.md
+++ b/recipes/promptable-video-redaction/README.md
@@ -69,7 +69,7 @@ pip install -r requirements.txt
    - On Ubuntu/Debian: `sudo apt-get install ffmpeg libvips`
    - On macOS: `brew install ffmpeg`
    - On Windows: Download from [ffmpeg.org](https://ffmpeg.org/download.html)
-     > Downloading libvips for Windows requires some additional steps, see [here](https://docs.moondream.ai/quick-start)
+     > Downloading libvips for Windows requires some additional steps, see [here](https://moondream.ai/c/docs/quickstart)
 
 ## Usage
 


### PR DESCRIPTION
The libvips Windows guide link https://docs.moondream.ai/quick-start 404s. Point all 4 sites at https://moondream.ai/c/docs/quickstart (verified 200, same target the root README.md uses).

Changed:
- recipes/promptable-video-redaction/README.md (libvips here-link)
- recipes/promptable-content-moderation/README.md (libvips guide + here-link)
- recipes/promptable-content-moderation/app.py (Quick Start link)

docs.moondream.ai/recipes links deliberately untouched (no verified replacement).
