### PR TITLE
docs: add missing article in run-on-the-cloud phrases

### DIFF
--- a/examples/quickstart/bash/README.md
+++ b/examples/quickstart/bash/README.md
@@ -9,7 +9,7 @@ Get started with Moondream's vision AI in Bash in minutes.
    - **Local**: Install [Moondream Station](https://moondream.ai/station)
    - **Cloud**: Get an API key from [Moondream Cloud](https://moondream.ai/cloud)
 
-2. Tweak the `main.sh` code if you want to run it on cloud
+2. Tweak the `main.sh` code if you want to run it on the cloud
 
 3. Run the examples to see Moondream in action!
 

--- a/examples/quickstart/bash/main.sh
+++ b/examples/quickstart/bash/main.sh
@@ -8,7 +8,7 @@ curl --location "http://localhost:2020/v1/{endpoint}" \
     "stream": false
   }'
 
-## To run on cloud
+## To run on the cloud
 # curl --location "https://api.moondream.ai/v1/{endpoint}"
 #   --header 'X-Moondream-Auth: ${MOONDREAM_API_KEY}' \
 #   --header 'Content-Type: application/json' \

--- a/examples/quickstart/node/README.md
+++ b/examples/quickstart/node/README.md
@@ -15,7 +15,7 @@ Get started with Moondream's vision AI in Node in minutes.
    npm install
    ```
 
-3. Tweak the `main.js` code if you want to run it on cloud.
+3. Tweak the `main.js` code if you want to run it on the cloud.
 
 4. Run the examples to see Moondream in action!
 


### PR DESCRIPTION
The node and bash quickstarts say 'run it on cloud' while the python quickstart already says 'on the cloud'. Fix the 3 sites for consistency:

- examples/quickstart/node/README.md
- examples/quickstart/bash/README.md
- examples/quickstart/bash/main.sh
